### PR TITLE
Fix all compiler warnings with -O.

### DIFF
--- a/common.h
+++ b/common.h
@@ -43,5 +43,8 @@ typedef int32_t SLONG;
 #define MAX(x, y) (((x)>(y))?(x):(y))
 #define MIN(x, y) (((x)<(y))?(x):(y))
 
+#define WARNING(F) \
+  fprintf(stderr, "WARNING: unexpected return value from %s at %s:%d\n", #F, __FILE__, __LINE__);
+
 #endif
 

--- a/cpu.c
+++ b/cpu.c
@@ -740,7 +740,8 @@ void cprint_load_labels(char *file)
   }
 
   while(!feof(f)) {
-    fscanf(f, "%14s %08X\n", name, &addr);
+    if(fscanf(f, "%14s %08X\n", name, &addr) != 2)
+      WARNING(fscanf);
     cprint_set_label(addr, strdup(name));
   }
   

--- a/expr.y
+++ b/expr.y
@@ -2,7 +2,7 @@
 %token <val> AREG DREG VAL WIN
 %token EQ NE LT LE GT GE BAND LAND BOR LOR BXOR BNOT LNOT
 %type <val> expr
-%name-prefix="expr"
+%name-prefix "expr"
 %left '-' '+'
 %left '*' '/'
 %{

--- a/psg.c
+++ b/psg.c
@@ -378,8 +378,10 @@ static void psg_generate_samples()
       psg_running = 1;
     if(psg_running) {
 #if PSGOUTPUT
-      write(snd_fd, &outsign, 2);
-      write(snd_fd, &outsign, 2);
+      if(write(snd_fd, &outsign, 2) != 2)
+	WARNING(write);
+      if(write(snd_fd, &outsign, 2) != 2)
+	WARNING(write);
 #endif
     }
     psg_presamplestart += PSG_PRESAMPLES_PER_SAMPLE;

--- a/shifter.c
+++ b/shifter.c
@@ -511,8 +511,10 @@ void shifter_build_ppm()
   }
 
   sprintf(header, "P6\n%d %d\n255\n", 384, 288);
-  write(ppm_fd, header, strlen(header));
-  write(ppm_fd, frame, 384*288*3);
+  if(write(ppm_fd, header, strlen(header)) != strlen(header))
+    WARNING(write);
+  if (write(ppm_fd, frame, 384*288*3) != 384*288*3)
+    WARNING(write);
 }
 
 void shifter_init()

--- a/state.c
+++ b/state.c
@@ -61,7 +61,8 @@ static void state_write_file_long(FILE *f, long data)
 static long state_read_file_long(FILE *f)
 {
   unsigned char tmp[4];
-  fread(tmp, 4, 1, f);
+  if(fread(tmp, 4, 1, f) != 1)
+    WARNING(fread);
 
   return (tmp[0]<<24)|(tmp[1]<<16)|(tmp[2]<<8)|tmp[3];
 }
@@ -111,7 +112,8 @@ static int state_read_section(FILE *f, struct state_section *sec)
     return STATE_INVALID;
   }
   if(sec->size%4)
-    fread(dummy, 4-(sec->size%4), 1, f);
+    if(fread(dummy, 4-(sec->size%4), 1, f) != 1)
+      WARNING(fread);
 
   return STATE_VALID;
 }


### PR DESCRIPTION
With optimisation enabled, gcc complains about ignored return values.  This just prints a warning on stderr.