### PR TITLE
Make -d a runtime switch to run the debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ tos.img
 psg.raw
 ostis.state
 ostis
-ostis-debug
 ostis-gdb

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,7 @@ TEST_PRG=ostistest
 all:	default
 
 default:
-	make ostis CFLAGS_EXTRA="-O3"
-
-debugger:
-	make ostis-debug CFLAGS_EXTRA="-DDEBUG=1 -O3"
+	make ostis CFLAGS_EXTRA="-DDEBUG=1 -O3"
 
 gdb:
 	make ostis-gdb CFLAGS_EXTRA="-ggdb"

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ TEST_PRG=ostistest
 all:	default
 
 default:
-	make ostis CFLAGS_EXTRA="-DDEBUG=1 -O3"
+	make ostis CFLAGS_EXTRA="-O3"
 
 gdb:
 	make ostis-gdb CFLAGS_EXTRA="-ggdb"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Normal binary with GDB flags:
 ### Usage
 
 Command line options:  
-`ostis` [`-a` disk image] [`-t` TOS image] [`-s` state image] [`-h`] [disk image]
+`ostis` [`-a` disk image] [`-t` TOS image] [`-s` state image] [`-h`] [`-d`] [disk image]
 
 Special keys:  
 `F11` - save emulator state to file  

--- a/common.h
+++ b/common.h
@@ -7,10 +7,6 @@
 #include <string.h>
 #include "screen.h"
 
-#ifndef DEBUG
-#define DEBUG 0
-#endif
-
 typedef uint8_t BYTE;
 typedef uint16_t WORD;
 typedef uint32_t LONG;

--- a/common.h
+++ b/common.h
@@ -46,5 +46,7 @@ typedef int32_t SLONG;
 #define WARNING(F) \
   fprintf(stderr, "WARNING: unexpected return value from %s at %s:%d\n", #F, __FILE__, __LINE__);
 
+extern int debugger;
+
 #endif
 

--- a/cpu.c
+++ b/cpu.c
@@ -678,10 +678,12 @@ static char *cprint_find_auto_label(LONG addr)
 
 void cprint_set_label(LONG addr, char *name)
 {
-#if DEBUG
   struct cprint_label *new;
   static char tname[10];
   char *tmp;
+
+  if(!debugger)
+    return;
 
   if(name) {
     tmp = cprint_find_label(addr);
@@ -704,7 +706,6 @@ void cprint_set_label(LONG addr, char *name)
   }
   new->next = clabel;
   clabel = new;
-#endif
 }
 
 void cprint_save_labels(char *file)

--- a/event.c
+++ b/event.c
@@ -30,13 +30,13 @@ static int event_key(SDL_KeyboardEvent key, int state)
     ikbd_queue_key(SCAN_F1+k.sym-SDLK_F1, state);
   } else if(k.sym == SDLK_F11) {
     if(state == EVENT_RELEASE) {
-#if DEBUG
-      return EVENT_DEBUG;
-#else
-      state_save("ostis.state", state_collect());
-      SDL_Quit();
-      exit(0);
-#endif
+      if(debugger)
+	return EVENT_DEBUG;
+      else {
+	state_save("ostis.state", state_collect());
+	SDL_Quit();
+	exit(0);
+      }
     }
   } else if(k.sym == SDLK_F12) {
     if(state == EVENT_RELEASE) {
@@ -130,12 +130,12 @@ int event_poll()
   case SDL_MOUSEBUTTONUP:
     return event_button(ev.button, EVENT_RELEASE);
   case SDL_QUIT:
-#if DEBUG
-    return EVENT_DEBUG;
-#else
-    SDL_Quit();
-    exit(0);
-#endif
+    if(debugger)
+      return EVENT_DEBUG;
+    else {
+      SDL_Quit();
+      exit(0);
+    }
   }
 
   return EVENT_NONE;

--- a/main.c
+++ b/main.c
@@ -18,6 +18,8 @@
 #include "cartridge.h"
 #include "state.h"
 
+int debugger = 0;
+
 int main(int argc, char *argv[])
 {
   int i,c;
@@ -26,7 +28,7 @@ int main(int argc, char *argv[])
   prefs_init();
 
   while(1) {
-    c = getopt(argc, argv, "a:t:s:h");
+    c = getopt(argc, argv, "a:t:s:hd");
     if(c == -1) break;
 
     switch(c) {
@@ -39,9 +41,12 @@ int main(int argc, char *argv[])
     case 's':
       prefs_set("stateimage", optarg);
       break;
+    case 'd':
+      debugger = 1;
+      break;
     case 'h':
     default:
-      printf("Usage: %s [-a diskimage] [-t tosimage] [-s stateimage]\n",
+      printf("Usage: %s [-a diskimage] [-t tosimage] [-s stateimage] [-h] [-d]\n",
 	     argv[0]);
       exit(-1);
       break;
@@ -65,9 +70,8 @@ int main(int argc, char *argv[])
   screen_disable(0);
   screen_init();
   shifter_init();
-#if DEBUG
-  debug_init();
-#endif
+  if(debugger)
+    debug_init();
 
 #if 0
   if(argc > 1) {
@@ -99,12 +103,12 @@ int main(int argc, char *argv[])
   if(state != NULL)
     state_restore(state);
 
-#if DEBUG
-  while(!debug_event());
-  return 0;
-#else
-  while(cpu_run());
-#endif
+  if(debugger) {
+    while(!debug_event());
+    return 0;
+  } else {
+    while(cpu_run());
+  }
 
   mmu_print_map();
   // cpu_print_status();

--- a/screen.c
+++ b/screen.c
@@ -16,10 +16,8 @@ static SDL_Surface *screen;
 
 void screen_init()
 {
-#if DEBUG
   /* should be rewritten with proper error checking */
   Uint32 rmask, gmask, bmask, amask;
-#endif
   
   if(disable) return;
 #if 0
@@ -28,26 +26,24 @@ void screen_init()
 #endif
   
 
-#if DEBUG
+  if(debugger) {
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-  amask = 0x00000000;
-  rmask = 0x00ff0000;
-  gmask = 0x0000ff00;
-  bmask = 0x000000ff;
+    amask = 0x00000000;
+    rmask = 0x00ff0000;
+    gmask = 0x0000ff00;
+    bmask = 0x000000ff;
 #else
-  amask = 0x00000000;
-  rmask = 0x000000ff;
-  gmask = 0x0000ff00;
-  bmask = 0x00ff0000;
-#endif
+    amask = 0x00000000;
+    rmask = 0x000000ff;
+    gmask = 0x0000ff00;
+    bmask = 0x00ff0000;
 #endif
   
-#if DEBUG
-  screen = SDL_CreateRGBSurface(SDL_SWSURFACE, 512, 314, 24,
-				rmask, gmask, bmask, amask);
-#else
-  screen = SDL_SetVideoMode(512, 314, 24, SDL_HWSURFACE|SDL_DOUBLEBUF);
-#endif
+    screen = SDL_CreateRGBSurface(SDL_SWSURFACE, 512, 314, 24,
+				  rmask, gmask, bmask, amask);
+  } else {
+    screen = SDL_SetVideoMode(512, 314, 24, SDL_HWSURFACE|SDL_DOUBLEBUF);
+  }
 
   if(screen == NULL) {
     fprintf(stderr, "Did not get a video mode\n");
@@ -116,20 +112,19 @@ void screen_putpixel(int x, int y, long c)
 
 void screen_swap()
 {
-#if DEBUG
   SDL_Rect dst;
-#endif
+
   if(disable) return;
 
-#if DEBUG
-  dst.x = BORDER_SIZE;
-  dst.y = BORDER_SIZE;
+  if(debugger) {
+    dst.x = BORDER_SIZE;
+    dst.y = BORDER_SIZE;
   
-  SDL_BlitSurface(screen, NULL, display_get_screen(), &dst);
-  SDL_Flip(display_get_screen());
-#else
-  SDL_Flip(screen);
-#endif
+    SDL_BlitSurface(screen, NULL, display_get_screen(), &dst);
+    SDL_Flip(display_get_screen());
+  } else {
+    SDL_Flip(screen);
+  }
 }
 
 void screen_disable(int yes)

--- a/shifter.c
+++ b/shifter.c
@@ -88,15 +88,15 @@ static void set_pixel_low(int rasterpos, int pnum)
 {
   //  if(pnum == 0) return;
 
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN) || DEBUG
-  rgbimage[rasterpos*3+0] = palette_r[pnum];
-  rgbimage[rasterpos*3+1] = palette_g[pnum];
-  rgbimage[rasterpos*3+2] = palette_b[pnum];
-#else
-  rgbimage[rasterpos*3+2] = palette_r[pnum];
-  rgbimage[rasterpos*3+1] = palette_g[pnum];
-  rgbimage[rasterpos*3+0] = palette_b[pnum];
-#endif
+  if(SDL_BYTEORDER == SDL_BIG_ENDIAN || debugger) {
+    rgbimage[rasterpos*3+0] = palette_r[pnum];
+    rgbimage[rasterpos*3+1] = palette_g[pnum];
+    rgbimage[rasterpos*3+2] = palette_b[pnum];
+  } else {
+    rgbimage[rasterpos*3+2] = palette_r[pnum];
+    rgbimage[rasterpos*3+1] = palette_g[pnum];
+    rgbimage[rasterpos*3+0] = palette_b[pnum];
+  }
 }
 
 static void set_pixel_medium(int rasterpos, int pnum)
@@ -111,15 +111,15 @@ static void set_pixel_medium(int rasterpos, int pnum)
   g = (palette_g[c1]+palette_g[c2])/2;
   b = (palette_b[c1]+palette_b[c2])/2;
 
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN) || DEBUG
-  rgbimage[rasterpos*3+0] = r;
-  rgbimage[rasterpos*3+1] = g;
-  rgbimage[rasterpos*3+2] = b;
-#else
-  rgbimage[rasterpos*3+2] = r;
-  rgbimage[rasterpos*3+1] = g;
-  rgbimage[rasterpos*3+0] = b;
-#endif
+  if(SDL_BYTEORDER == SDL_BIG_ENDIAN || debugger) {
+    rgbimage[rasterpos*3+0] = r;
+    rgbimage[rasterpos*3+1] = g;
+    rgbimage[rasterpos*3+2] = b;
+  } else {
+    rgbimage[rasterpos*3+2] = r;
+    rgbimage[rasterpos*3+1] = g;
+    rgbimage[rasterpos*3+0] = b;
+  }
 }
 
 static void set_pixel(int rasterpos, int pnum)


### PR DESCRIPTION
Divided into three steps:
- Add -d option, only works in ostis-debugger.
- Make ostis-debugger the default, replacing the old ostis
- Remove -DDEBUG=1.