### PR TITLE
Fixes for IKBD

### DIFF
--- a/event.c
+++ b/event.c
@@ -18,7 +18,7 @@ static int event_key(SDL_KeyboardEvent key, int state)
   Uint16 u;
 
   k = key.keysym;
-  u = k.unicode;
+  u = k.unicode ? k.unicode : k.sym;
 
   if((u == ' ') ||
      ((u >= '0') && (u <= '9')) ||

--- a/ikbd.c
+++ b/ikbd.c
@@ -48,7 +48,7 @@ static int ikbd_pop_fifo()
   memmove(&ikbd_fifo[0], &ikbd_fifo[1], IKBDFIFO-1);
   ikbd_fifocnt--;
   if(ikbd_fifocnt > 0)
-    ikbd_status |= 0x1;
+    ikbd_status |= 0x81;
   return tmp;
 }
 
@@ -66,7 +66,7 @@ static void ikbd_queue_fifo(BYTE data)
   }
   ikbd_fifo[ikbd_fifocnt] = data;
   ikbd_fifocnt++;
-  ikbd_status |= 0x1;
+  ikbd_status |= 0x81;
 }
 
 static BYTE ikbd_read_byte(LONG addr)
@@ -269,7 +269,7 @@ void ikbd_do_interrupts(struct cpu *cpu)
     if(ikbd_intcnt <= 0) {
       if(ikbd_control&0x80) {
 	if(ikbd_fifocnt > 0) {
-	  ikbd_status |= 0x80;
+	  ikbd_status |= 0x81;
 	  mfp_clr_GPIP(4);
 	  //printf("DEBUG: sending keyboard interrupt\n");
 	  mfp_set_pending(6);

--- a/ikbd.c
+++ b/ikbd.c
@@ -43,7 +43,7 @@ static int ikbd_pop_fifo()
 {
   BYTE tmp;
 
-  if(ikbd_fifocnt == 0) return 0;
+  if(ikbd_fifocnt == 0) return -1;
   tmp = ikbd_fifo[0];
   memmove(&ikbd_fifo[0], &ikbd_fifo[1], IKBDFIFO-1);
   ikbd_fifocnt--;
@@ -71,7 +71,8 @@ static void ikbd_queue_fifo(BYTE data)
 
 static BYTE ikbd_read_byte(LONG addr)
 {
-  BYTE tmp;
+  static BYTE last = 0;
+  int tmp;
 
   switch(addr) {
   case 0xfffc00:
@@ -83,7 +84,10 @@ static BYTE ikbd_read_byte(LONG addr)
     else
       ikbd_intcnt = 0;
     tmp = ikbd_pop_fifo();
-    return tmp;
+    if(tmp == -1)
+      return last;
+    else
+      return last = tmp;
   default:
     return 0;
   }


### PR DESCRIPTION
- The "receive data register" isn't cleared by a read
- Released keys weren't recognised properly.
- The interrupt bit shout be set as soon as the receive data register full bit is set.

Good reading:
http://www.classiccmp.org/dunfield/r/6850.pdf