### PR TITLE
IKBD: more commands, multi-byte

### DIFF
--- a/state.c
+++ b/state.c
@@ -35,6 +35,16 @@ void state_write_mem_long(char *ptr, LONG data)
   ptr[3] = data;
 }
 
+void state_write_mem_ptr(char *ptr, void *data)
+{
+  intptr_t x = (intptr_t)data;
+  int i;
+  for(i = 0; i < sizeof data; i++) {
+    ptr[i] = (char)x;
+    x >>= 8;
+  }
+}
+
 BYTE state_read_mem_byte(char *ptr)
 {
   return ptr[0];
@@ -48,6 +58,16 @@ WORD state_read_mem_word(char *ptr)
 LONG state_read_mem_long(char *ptr)
 {
   return (ptr[0]<<24)|(ptr[1]<<16)|(ptr[2]<<8)|ptr[3];
+}
+
+void *state_read_mem_ptr(char *ptr)
+{
+  intptr_t x = 0;
+  int i;
+  for(i = 0; i < sizeof x; i++) {
+    x += (ptr[i] & 0xff) << (i*8);
+  }
+  return (void *)x;
 }
 
 static void state_write_file_long(FILE *f, long data)

--- a/state.h
+++ b/state.h
@@ -34,8 +34,10 @@ int state_valid_id(char *);
 void state_write_mem_byte(char *, BYTE);
 void state_write_mem_word(char *, WORD);
 void state_write_mem_long(char *, LONG);
+void state_write_mem_ptr(char *, void *);
 BYTE state_read_mem_byte(char *);
 WORD state_read_mem_word(char *);
 LONG state_read_mem_long(char *);
+void *state_read_mem_ptr(char *);
 
 #endif


### PR DESCRIPTION
Recognise all IKBD commands sent by TOS 1.00:
- 0x07 configure mouse buttons
- 0x0B mouse threshold
- 0x10 set y origin
- 0x1a disable joystick
- 0x80 reset

Some of those are more than one byte, so add support for that.

The commands mostly don't do anything.  Reset sends a `0xF1` reply.