### PR TITLE
Automatically generate dependencies for all .c files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.o
 *.a
+*.d
 expr.tab.c
 expr.tab.h
 lex.expr.c

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ DEPS_TEST = $(EMU_TEST_OBJ) $(LIBCPU) $(LIBDEBUG) $(PARSEROBJ) $(LIBTESTS)
 
 LIB=$(LIBCPU) $(LIBDEBUG) `sdl2-config --libs`
 
-%.o:	%.c
-	$(CC) $(CFLAGS) -c $< -o $@
-
 all:	default
+
+-include $(EMU_SRC:.c=.d)
+
+%.o:	%.c
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
 
 default:
 	$(MAKE) ostis CFLAGS_EXTRA="-O3"
@@ -80,4 +82,4 @@ include debug/debug.mk
 include tests/tests.mk
 
 clean::
-	rm -f *.o *~ $(PARSERSRC) expr.tab.h ostis ostis-gdb ostis-test
+	rm -f *.o *.d *~ $(PARSERSRC) expr.tab.h ostis ostis-gdb ostis-test

--- a/cpu/cpu.mk
+++ b/cpu/cpu.mk
@@ -10,9 +10,11 @@ CPU_SRC=$(addprefix cpu/,ea.c move_to_sr.c reset.c cmpi.c bcc.c lea.c	\
     roxr.c bchg.c abcd.c stop.c sbcd.c tas.c andi_to_ccr.c rtr.c)
 CPU_OBJ=$(CPU_SRC:.c=.o)
 
+-include $(CPU_SRC:.c=.d)
+
 $(LIBCPU): $(CPU_OBJ)
 	$(AR) cru $@ $(CPU_OBJ)
 	$(RANLIB) $@
 
 clean::
-	rm -f $(CPU_OBJ) $(LIBCPU) cpu/*~
+	rm -f $(CPU_OBJ) $(LIBCPU) cpu/*~ cpu/*.d

--- a/debug/debug.mk
+++ b/debug/debug.mk
@@ -1,9 +1,11 @@
 DEBUG_SRC=$(addprefix debug/,debug.c display.c draw.c edit.c layout.c win.c)
 DEBUG_OBJ=$(DEBUG_SRC:.c=.o)
 
+-include $(DEBUG_SRC:.c=.d)
+
 $(LIBDEBUG): $(DEBUG_OBJ)
 	$(AR) cru $@ $(DEBUG_OBJ)
 	$(RANLIB) $@
 
 clean::
-	rm -f $(DEBUG_OBJ) $(LIBDEBUG) debug/*~
+	rm -f $(DEBUG_OBJ) $(LIBDEBUG) debug/*~ debug/*.d

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -1,9 +1,11 @@
 TESTS_SRC=$(addprefix tests/,test_moveq.c test_roxl.c test_roxr.c test_lsl.c test_prefetch1.c)
 TESTS_OBJ=$(TESTS_SRC:.c=.o)
 
+-include $(TESTS_SRC:.c=.d)
+
 $(LIBTESTS): $(TESTS_OBJ)
 	$(AR) cru $@ $(TESTS_OBJ)
 	$(RANLIB) $@
 
 clean::
-	rm -f $(TESTS_OBJ) $(LIBTESTS) tests/*~
+	rm -f $(TESTS_OBJ) $(LIBTESTS) tests/*~ tests/*.d


### PR DESCRIPTION
Now, editing header files will trigger a rebuild.