### PR TITLE
Split off ACIA from IKBD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PARSEROBJ=$(PARSERSRC:.c=.o)
 
 SRC=mmu.c mmu_fallback.c ram.c rom.c cpu.c cartridge.c psg.c mfp.c shifter.c screen.c \
     midi.c ikbd.c dma.c fdc.c hdc.c rtc.c floppy.c floppy_st.c floppy_msa.c floppy_stx.c event.c \
-    state.c prefs.c cprint.c diag.c
+    state.c prefs.c cprint.c diag.c acia.c
 SRC_TEST=tests/test_main.c
 OBJ=$(SRC:.c=.o)
 

--- a/acia.c
+++ b/acia.c
@@ -1,0 +1,136 @@
+#include "common.h"
+#include "mmu.h"
+#include "mfp.h"
+#include "ikbd.h"
+#include "diag.h"
+
+#define ACIASIZE 4
+#define ACIABASE 0xfffc00
+
+#define ACIA_RX_FULL     0x01
+#define ACIA_TX_EMPTY    0x02
+#define ACIA_RX_OVERRUN  0x20
+#define ACIA_IRQ         0x80
+#define ACIA_IE          0x80
+
+static BYTE acia_control;
+static BYTE acia_status;
+static BYTE rx_data;
+
+HANDLE_DIAGNOSTICS(acia)
+
+int acia_rx_full()
+{
+  return acia_status & ACIA_RX_FULL;
+}
+
+static void set_status(BYTE data)
+{
+  acia_status = data;
+  if((acia_control & ACIA_IE) && (acia_status & ACIA_IRQ))
+    mfp_clr_GPIP(MFP_GPIP_ACIA);
+  else
+    mfp_set_GPIP(MFP_GPIP_ACIA);
+}
+
+void acia_rx_data(BYTE data)
+{
+  TRACE("Rx %02x", data);
+  rx_data = data;
+  set_status(acia_status | ACIA_RX_FULL | ACIA_IRQ);
+}
+
+static void acia_reset(void)
+{
+  acia_control = 0;
+  rx_data = 0;
+  set_status(ACIA_TX_EMPTY);
+}
+
+static BYTE acia_read_byte(LONG addr)
+{
+  BYTE data;
+  cpu_add_extra_cycles(6);
+
+  switch(addr) {
+  case 0xfffc00:
+    return acia_status;
+  case 0xfffc02:
+    set_status(acia_status & ~(ACIA_RX_FULL | ACIA_IRQ));
+    data = rx_data;
+    TRACE("Read %02x", data);
+    return data;
+  default:
+    return 0;
+  }
+}
+
+static WORD acia_read_word(LONG addr)
+{
+  return (acia_read_byte(addr)<<8)|acia_read_byte(addr+1);
+}
+
+static LONG acia_read_long(LONG addr)
+{
+  return ((acia_read_byte(addr)<<24)|
+	  (acia_read_byte(addr+1)<<16)|
+	  (acia_read_byte(addr+2)<<8)|
+	  (acia_read_byte(addr+3)));
+}
+
+static void acia_write_byte(LONG addr, BYTE data)
+{
+  cpu_add_extra_cycles(6);
+
+  switch(addr) {
+  case 0xfffc00:
+    DEBUG("Control %02x", data);
+    if(data == 3) {
+      DEBUG("Reset");
+      acia_reset();
+    } else if((data & 0x7C) != 0x14)
+      DEBUG("Unsupported configuration");
+    acia_control = data;
+    break;
+  case 0xfffc02:
+    TRACE("Write %02x", data);
+    ikbd_write_byte(data);
+    break;
+  }
+}
+
+static void acia_write_word(LONG addr, WORD data)
+{
+  acia_write_byte(addr, (data&0xff00)>>8);
+  acia_write_byte(addr+1, (data&0xff));
+}
+
+static void acia_write_long(LONG addr, LONG data)
+{
+  acia_write_byte(addr, (data&0xff000000)>>24);
+  acia_write_byte(addr+1, (data&0xff0000)>>16);
+  acia_write_byte(addr+2, (data&0xff00)>>8);
+  acia_write_byte(addr+3, (data&0xff));
+}
+
+void acia_init()
+{
+  struct mmu *acia;
+
+  acia = mmu_create("ACIA", "ACIA");
+  if(!acia) {
+    return;
+  }
+  acia->start = ACIABASE;
+  acia->size = ACIASIZE;
+  acia->read_byte = acia_read_byte;
+  acia->read_word = acia_read_word;
+  acia->read_long = acia_read_long;
+  acia->write_byte = acia_write_byte;
+  acia->write_word = acia_write_word;
+  acia->write_long = acia_write_long;
+  acia->diagnostics = acia_diagnostics;
+
+  mmu_register(acia);
+  acia_reset();
+}

--- a/acia.h
+++ b/acia.h
@@ -1,0 +1,10 @@
+#ifndef ACIA_H
+#define ACIA_H
+
+#include "cpu.h"
+
+void acia_init(void);
+int acia_rx_full(void);
+void acia_rx_data(BYTE);
+
+#endif

--- a/cpu.c
+++ b/cpu.c
@@ -226,10 +226,8 @@ int cpu_step_instr(int trace)
     if(cprint_all) {
       struct cprint *cprint;
       cprint = cprint_instr(cpu->pc-2);
-      fprintf(stderr, "DEBUG-ASM: %04x %02x (%d) %06X      %s %s",
+      fprintf(stderr, "DEBUG-ASM: %04x %06X      %s %s",
              cpu->sr,
-             mfp_get_ISRB(),
-             ikbd_get_fifocnt(),
              cpu->pc-2,
              cprint->instr,
              cprint->data);

--- a/ikbd.c
+++ b/ikbd.c
@@ -31,11 +31,6 @@ static void ikbd_do_interrupts(struct cpu *cpu);
 
 HANDLE_DIAGNOSTICS(ikbd)
 
-int ikbd_get_fifocnt()
-{
-  return ikbd_fifocnt;
-}
-
 void ikbd_print_status()
 {
   int i;

--- a/ikbd.c
+++ b/ikbd.c
@@ -17,7 +17,7 @@ static BYTE ikbd_fifo[IKBDFIFO];
 static int ikbd_fifocnt = 0;
 static uint64_t ikbd_next_interrupt_cycle = 0;
 static BYTE ikbd_buttons = 0;
-static BYTE ikbd_mouse_enabled = 1;
+static BYTE ikbd_mouse_enabled = 0;
 static int ikbd_mouse_inverted = 0;
 static int ikbd_absolute_x = 0;
 static int ikbd_absolute_y = 0;
@@ -136,6 +136,8 @@ static void ikbd_do_reset(void)
   ikbd_mouse_enabled = 1;
   ikbd_mouse_inverted = 0;
   ikbd_joystick_enabled = 0;
+  ikbd_fifocnt = 0;
+  ikbd_cmdcnt = 0;
 }
 
 static void ikbd_reset(void)
@@ -363,8 +365,6 @@ void ikbd_fire(int state)
 void ikbd_init()
 {
   HANDLE_DIAGNOSTICS_NON_MMU_DEVICE(ikbd, "IKBD");
-
-  ikbd_do_reset();
 }
 
 void ikbd_do_interrupt(struct cpu *cpu)

--- a/ikbd.c
+++ b/ikbd.c
@@ -6,17 +6,13 @@
 #include "event.h"
 #include "mmu.h"
 #include "mfp.h"
+#include "acia.h"
 #include "state.h"
 #include "diag.h"
 
-#define IKBDSIZE 4
-#define IKBDBASE 0xfffc00
-
 #define IKBDFIFO 32
-#define IKBD_INTINTERVAL 1024
+#define IKBD_INTINTERVAL 10000
 
-static BYTE ikbd_control;
-static BYTE ikbd_status = 0x2; /* Always ready */
 static BYTE ikbd_fifo[IKBDFIFO];
 static int ikbd_fifocnt = 0;
 static uint64_t ikbd_next_interrupt_cycle = 0;
@@ -44,8 +40,6 @@ void ikbd_print_status()
 {
   int i;
   printf("IKBD:\n");
-  printf("Status: %02x\n", ikbd_status);
-  printf("Control: %02x\n", ikbd_control);
   printf("Next interrupt cycle: %lld\n", (long long)ikbd_next_interrupt_cycle);
   printf("FIFO count: %d\n", ikbd_fifocnt);
   printf("FIFO:\n");
@@ -238,94 +232,35 @@ static int ikbd_pop_fifo()
   tmp = ikbd_fifo[0];
   memmove(&ikbd_fifo[0], &ikbd_fifo[1], IKBDFIFO-1);
   ikbd_fifocnt--;
-  if(ikbd_fifocnt > 0) {
-    ikbd_status |= 0x81;
-  } else {
-    mfp_set_GPIP(MFP_GPIP_ACIA);
-  }
   return tmp;
+}
+
+static void ikbd_poll(void)
+{
+  if(ikbd_fifocnt > 0 && !acia_rx_full()) {
+    acia_rx_data(ikbd_pop_fifo());
+  }
 }
 
 static void ikbd_queue_fifo(BYTE data)
 {
   if(ikbd_fifocnt == IKBDFIFO) {
-    ikbd_status |= 0x20;
     DEBUG("Overrun");
   } else {
     ikbd_fifo[ikbd_fifocnt] = data;
     ikbd_fifocnt++;
   }
-  ikbd_status |= 0x81;
 }
 
-static BYTE ikbd_read_byte(LONG addr)
+void ikbd_write_byte(BYTE data)
 {
-  static BYTE last = 0;
-  int tmp;
-
-  cpu_add_extra_cycles(6);
-
-  switch(addr) {
-  case 0xfffc00:
-    return ikbd_status;
-  case 0xfffc02:
-    ikbd_status &= ~0xa1;
-    tmp = ikbd_pop_fifo();
-    if(tmp == -1)
-      return last;
-    else
-      return last = tmp;
-  default:
-    return 0;
+  if(ikbd_cmdcnt == 0) {
+    ikbd_set_cmd(data);
+  } else {
+    ikbd_cmdbuf[--ikbd_cmdcnt] = data;
+    if(ikbd_cmdcnt == 0)
+      ikbd_cmdfn();
   }
-}
-
-static WORD ikbd_read_word(LONG addr)
-{
-  return (ikbd_read_byte(addr)<<8)|ikbd_read_byte(addr+1);
-}
-
-static LONG ikbd_read_long(LONG addr)
-{
-  return ((ikbd_read_byte(addr)<<24)|
-	  (ikbd_read_byte(addr+1)<<16)|
-	  (ikbd_read_byte(addr+2)<<8)|
-	  (ikbd_read_byte(addr+3)));
-}
-
-static void ikbd_write_byte(LONG addr, BYTE data)
-{
-  cpu_add_extra_cycles(6);
-
-  switch(addr) {
-  case 0xfffc00:
-    ikbd_control = data;
-    break;
-  case 0xfffc02:
-    ikbd_status &= ~0x80;
-    if(ikbd_cmdcnt == 0) {
-      ikbd_set_cmd(data);
-    } else {
-      ikbd_cmdbuf[--ikbd_cmdcnt] = data;
-      if(ikbd_cmdcnt == 0)
-	ikbd_cmdfn();
-    }
-    break;
-  }
-}
-
-static void ikbd_write_word(LONG addr, WORD data)
-{
-  ikbd_write_byte(addr, (data&0xff00)>>8);
-  ikbd_write_byte(addr+1, (data&0xff));
-}
-
-static void ikbd_write_long(LONG addr, LONG data)
-{
-  ikbd_write_byte(addr, (data&0xff000000)>>24);
-  ikbd_write_byte(addr+1, (data&0xff0000)>>16);
-  ikbd_write_byte(addr+2, (data&0xff00)>>8);
-  ikbd_write_byte(addr+3, (data&0xff));
 }
 
 static int ikbd_state_collect(struct mmu_state *state)
@@ -339,8 +274,6 @@ static int ikbd_state_collect(struct mmu_state *state)
    * lastcpucnt           == 4
    * ikbd_fifosize        == 4
    * ikbd_fifo            == 1*fifosize
-   * ikbd_control         == 1
-   * ikbd_status          == 1
    * ikbd_mouse_enabled   == 1
    * cmdbuf               == cmdbuf size
    * cmdcnt               == 1
@@ -358,8 +291,6 @@ static int ikbd_state_collect(struct mmu_state *state)
   for(r=0;r<IKBDFIFO;r++) {
     state_write_mem_byte(&state->data[16+r], ikbd_fifo[r]);
   }
-  state_write_mem_byte(&state->data[16+IKBDFIFO], ikbd_control);
-  state_write_mem_byte(&state->data[16+IKBDFIFO+1], ikbd_status);
   state_write_mem_byte(&state->data[16+IKBDFIFO+2], ikbd_mouse_enabled);
   state_write_mem_byte(&state->data[16+IKBDFIFO+3], ikbd_cmdcnt);
   for(r=0;r<sizeof ikbd_cmdbuf;r++) {
@@ -381,8 +312,6 @@ static void ikbd_state_restore(struct mmu_state *state)
   for(r=0;r<fifosize;r++) {
     ikbd_fifo[r] = state_read_mem_byte(&state->data[16+r]);
   }
-  ikbd_control = state_read_mem_byte(&state->data[16+IKBDFIFO]);
-  ikbd_status = state_read_mem_byte(&state->data[16+IKBDFIFO+1]);
   ikbd_mouse_enabled = state_read_mem_byte(&state->data[16+IKBDFIFO+3]);
   ikbd_cmdcnt = state_read_mem_byte(&state->data[16+IKBDFIFO+3]);
   for(r=0;r<sizeof ikbd_cmdbuf;r++) {
@@ -438,40 +367,15 @@ void ikbd_fire(int state)
 
 void ikbd_init()
 {
-  struct mmu *ikbd;
-
-  ikbd = mmu_create("IKBD", "Intelligent keyboard");
-  ikbd->start = IKBDBASE;
-  ikbd->size = IKBDSIZE;
-  ikbd->read_byte = ikbd_read_byte;
-  ikbd->read_word = ikbd_read_word;
-  ikbd->read_long = ikbd_read_long;
-  ikbd->write_byte = ikbd_write_byte;
-  ikbd->write_word = ikbd_write_word;
-  ikbd->write_long = ikbd_write_long;
-  ikbd->state_collect = ikbd_state_collect;
-  ikbd->state_restore = ikbd_state_restore;
-  ikbd->diagnostics = ikbd_diagnostics;
-  ikbd->interrupt = ikbd_do_interrupts;
-
-  mmu_register(ikbd);
+  HANDLE_DIAGNOSTICS_NON_MMU_DEVICE(ikbd, "IKBD");
 
   ikbd_do_reset();
 }
 
-static void ikbd_do_interrupts(struct cpu *cpu)
+void ikbd_do_interrupt(struct cpu *cpu)
 {
   if(cpu->cycle > ikbd_next_interrupt_cycle) {
-    if(ikbd_control&0x80) {
-      if(ikbd_fifocnt > 0) {
-        ikbd_status |= 0x81;
-        mfp_clr_GPIP(MFP_GPIP_ACIA);
-      } else {
-        ikbd_status &= ~(0x1);
-        mfp_set_GPIP(MFP_GPIP_ACIA);
-      }
-    }
-
+    ikbd_poll();
     ikbd_next_interrupt_cycle = cpu->cycle + IKBD_INTINTERVAL;
   }
 }

--- a/ikbd.h
+++ b/ikbd.h
@@ -17,7 +17,6 @@ void ikbd_joystick(int direction);
 void ikbd_fire(int state);
 void ikbd_do_interrupt(struct cpu *);
 void ikbd_print_status();
-int ikbd_get_fifocnt();
 void ikbd_write_byte(BYTE);
 
 #endif

--- a/ikbd.h
+++ b/ikbd.h
@@ -15,7 +15,9 @@ void ikbd_queue_motion(int, int);
 void ikbd_button(int, int);
 void ikbd_joystick(int direction);
 void ikbd_fire(int state);
+void ikbd_do_interrupt(struct cpu *);
 void ikbd_print_status();
 int ikbd_get_fifocnt();
+void ikbd_write_byte(BYTE);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@
 #include "cpu.h"
 #include "psg.h"
 #include "midi.h"
+#include "acia.h"
 #include "ikbd.h"
 #include "diag.h"
 #if INCLUDE_RTC
@@ -205,6 +206,7 @@ int main(int argc, char *argv[])
   }
   psg_init();
   midi_init();
+  acia_init();
   ikbd_init();
 #if INCLUDE_RTC
   rtc_init();

--- a/mfp.c
+++ b/mfp.c
@@ -306,11 +306,6 @@ static void update_timer(int tnum, long cycles)
   }
 }
 
-BYTE mfp_get_ISRB()
-{
-  return mfpreg[ISRB];
-}
-
 static int mfp_get_GPIP(int bnum)
 {
   return mfpreg[GPIP] & (1<<bnum);

--- a/mfp.h
+++ b/mfp.h
@@ -15,6 +15,4 @@ void mfp_do_timerb_event(struct cpu *);
 void mfp_set_GPIP(int);
 void mfp_clr_GPIP(int);
 
-BYTE mfp_get_ISRB();
-
 #endif

--- a/mmu.c
+++ b/mmu.c
@@ -5,6 +5,7 @@
 #include "mfp.h"
 #include "shifter.h"
 #include "ikbd.h"
+#include "acia.h"
 #include "psg.h"
 #include "dma.h"
 #include "fdc.h"
@@ -434,5 +435,6 @@ void mmu_do_interrupts(struct cpu *cpu)
   }
 
   fdc_do_interrupts(cpu);
+  ikbd_do_interrupt(cpu);
 }
 


### PR DESCRIPTION
Resulting software matches the hardware more closely.  This seems to fix the problem with e.g. Populous.