### PR TITLE
Update functions for bus accesses

### DIFF
--- a/acia.c
+++ b/acia.c
@@ -90,14 +90,6 @@ static WORD acia_read_word(LONG addr)
   return (acia_read_byte(addr)<<8)|acia_read_byte(addr+1);
 }
 
-static LONG acia_read_long(LONG addr)
-{
-  return ((acia_read_byte(addr)<<24)|
-	  (acia_read_byte(addr+1)<<16)|
-	  (acia_read_byte(addr+2)<<8)|
-	  (acia_read_byte(addr+3)));
-}
-
 static void acia_write_byte(LONG addr, BYTE data)
 {
   cpu_add_extra_cycles(6);
@@ -125,14 +117,6 @@ static void acia_write_word(LONG addr, WORD data)
   acia_write_byte(addr+1, (data&0xff));
 }
 
-static void acia_write_long(LONG addr, LONG data)
-{
-  acia_write_byte(addr, (data&0xff000000)>>24);
-  acia_write_byte(addr+1, (data&0xff0000)>>16);
-  acia_write_byte(addr+2, (data&0xff00)>>8);
-  acia_write_byte(addr+3, (data&0xff));
-}
-
 void acia_init()
 {
   struct mmu *acia;
@@ -145,10 +129,8 @@ void acia_init()
   acia->size = ACIASIZE;
   acia->read_byte = acia_read_byte;
   acia->read_word = acia_read_word;
-  acia->read_long = acia_read_long;
   acia->write_byte = acia_write_byte;
   acia->write_word = acia_write_word;
-  acia->write_long = acia_write_long;
   acia->diagnostics = acia_diagnostics;
 
   mmu_register(acia);

--- a/cartridge.c
+++ b/cartridge.c
@@ -28,14 +28,6 @@ static WORD cartridge_read_word(LONG addr)
   return (cartridge_read_byte(addr)<<8)|cartridge_read_byte(addr+1);
 }
 
-static LONG cartridge_read_long(LONG addr)
-{
-  return ((cartridge_read_byte(addr)<<24)|
-       (cartridge_read_byte(addr+1)<<16)|
-       (cartridge_read_byte(addr+2)<<8)|
-       (cartridge_read_byte(addr+3)));
-}
-
 static int cartridge_state_collect(struct mmu_state *state)
 {
   state->size = 0;
@@ -62,7 +54,6 @@ void cartridge_init(char *filename)
   cartridge->size = CARTRIDGESIZE;
   cartridge->read_byte = cartridge_read_byte;
   cartridge->read_word = cartridge_read_word;
-  cartridge->read_long = cartridge_read_long;
   cartridge->state_collect = cartridge_state_collect;
   cartridge->state_restore = cartridge_state_restore;
   cartridge->diagnostics = cartridge_diagnostics;

--- a/cprint.c
+++ b/cprint.c
@@ -171,10 +171,10 @@ struct cprint *cprint_instr(LONG addr)
     if(cpu->has_prefetched) {
       op = cpu->prefetched_instr;
     } else {
-      op = mmu_read_word_print(addr);
+      op = bus_read_word_print(addr);
     }
   } else {
-    op = mmu_read_word_print(addr);
+    op = bus_read_word_print(addr);
   }
   
   return instr_print[op](addr, op);

--- a/cpu/abcd.c
+++ b/cpu/abcd.c
@@ -17,12 +17,12 @@ static void abcd(struct cpu *cpu, WORD op)
       cpu->a[ry] -= 2;
     else
       cpu->a[ry] -= 1;
-    sb = mmu_read_byte(cpu->a[ry]);
+    sb = bus_read_byte(cpu->a[ry]);
     if(rx == 7)
       cpu->a[rx] -= 2;
     else
       cpu->a[rx] -= 1;
-    db = mmu_read_byte(cpu->a[rx]);
+    db = bus_read_byte(cpu->a[rx]);
     s = 10*((sb&0xf0)>>4)+((sb&0xf));
     d = 10*((db&0xf0)>>4)+((db&0xf));
     r = s+d;
@@ -31,7 +31,7 @@ static void abcd(struct cpu *cpu, WORD op)
     if(r&0xff) SETZ;
     rb = (r%10)|(((r/10)%10)<<4);
     cpu_prefetch();
-    mmu_write_byte(cpu->a[rx], rb);
+    bus_write_byte(cpu->a[rx], rb);
     ADD_CYCLE(18);
   } else {
     sb = cpu->d[ry]&0xff;

--- a/cpu/addi.c
+++ b/cpu/addi.c
@@ -8,7 +8,7 @@ static void addi_b(struct cpu *cpu, WORD op)
 {
   BYTE s,d,r;
   
-  s = mmu_read_word(cpu->pc)&0xff;
+  s = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   if(op&0x38) {
     ADD_CYCLE(12);
@@ -26,7 +26,7 @@ static void addi_w(struct cpu *cpu, WORD op)
 {
   WORD s,d,r;
   
-  s = mmu_read_word(cpu->pc);
+  s = bus_read_word(cpu->pc);
   cpu->pc += 2;
   if(op&0x38) {
     ADD_CYCLE(12);
@@ -44,7 +44,7 @@ static void addi_l(struct cpu *cpu, WORD op)
 {
   LONG s,d,r;
   
-  s = mmu_read_long(cpu->pc);
+  s = bus_read_long(cpu->pc);
   cpu->pc += 4;
   if(op&0x38) {
     ADD_CYCLE(20);
@@ -90,7 +90,7 @@ static struct cprint *addi_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "ADDI.B");
-    b = mmu_read_word_print(addr+ret->size)&0xff;
+    b = bus_read_word_print(addr+ret->size)&0xff;
     r = b;
     if(r&0x80) r |= 0xffffff00;
     if((r >= -128) && (r <= 127))
@@ -101,7 +101,7 @@ static struct cprint *addi_print(LONG addr, WORD op)
     break;
   case 1:
     strcpy(ret->instr, "ADDI.W");
-    w = mmu_read_word_print(addr+ret->size);
+    w = bus_read_word_print(addr+ret->size);
     r = w;
     if(r&0x8000) r |= 0xffff0000;
     if((r >= -128) && (r <= 127))
@@ -112,7 +112,7 @@ static struct cprint *addi_print(LONG addr, WORD op)
     break;
   case 2:
     strcpy(ret->instr, "ADDI.L");
-    l = mmu_read_long_print(addr+ret->size);
+    l = bus_read_long_print(addr+ret->size);
     r = (int)*((SLONG *)&l);
     if((r >= -128) && (r <= 127))
       sprintf(ret->data, "#%d,", r);

--- a/cpu/addx.c
+++ b/cpu/addx.c
@@ -17,16 +17,16 @@ static void addx_b(struct cpu *cpu, WORD op)
       cpu->a[ry] -= 2;
     else
       cpu->a[ry] -= 1;
-    s = mmu_read_byte(cpu->a[ry]);
+    s = bus_read_byte(cpu->a[ry]);
     if(rx == 7)
       cpu->a[rx] -= 2;
     else
       cpu->a[rx] -= 1;
-    d = mmu_read_byte(cpu->a[rx]);
+    d = bus_read_byte(cpu->a[rx]);
     r = s+d;
     if(CHKX) r += 1;
     cpu_prefetch();
-    mmu_write_byte(cpu->a[rx], r);
+    bus_write_byte(cpu->a[rx], r);
     ADD_CYCLE(18);
   } else {
     s = cpu->d[ry]&0xff;
@@ -51,13 +51,13 @@ static void addx_w(struct cpu *cpu, WORD op)
 
   if(op&0x8) {
     cpu->a[ry] -= 2;
-    s = mmu_read_word(cpu->a[ry]);
+    s = bus_read_word(cpu->a[ry]);
     cpu->a[rx] -= 2;
-    d = mmu_read_word(cpu->a[rx]);
+    d = bus_read_word(cpu->a[rx]);
     r = s+d;
     if(CHKX) r += 1;
     cpu_prefetch();
-    mmu_write_word(cpu->a[rx], r);
+    bus_write_word(cpu->a[rx], r);
     ADD_CYCLE(18);
   } else {
     s = cpu->d[ry]&0xffff;
@@ -82,13 +82,13 @@ static void addx_l(struct cpu *cpu, WORD op)
 
   if(op&0x8) {
     cpu->a[ry] -= 4;
-    s = mmu_read_long(cpu->a[ry]);
+    s = bus_read_long(cpu->a[ry]);
     cpu->a[rx] -= 4;
-    d = mmu_read_long(cpu->a[rx]);
+    d = bus_read_long(cpu->a[rx]);
     r = s+d;
     if(CHKX) r += 1;
     cpu_prefetch();
-    mmu_write_long(cpu->a[rx], r);
+    bus_write_long(cpu->a[rx], r);
     ADD_CYCLE(30);
   } else {
     s = cpu->d[ry];

--- a/cpu/andi.c
+++ b/cpu/andi.c
@@ -13,7 +13,7 @@ static void andi_b(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc)&0xff;
+  s = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   d = ea_read_byte(cpu, op&0x3f, 1);
   r = s&d;
@@ -31,7 +31,7 @@ static void andi_w(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc);
+  s = bus_read_word(cpu->pc);
   cpu->pc += 2;
   d = ea_read_word(cpu, op&0x3f, 1);
   r = s&d;
@@ -49,7 +49,7 @@ static void andi_l(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(16);
   }
-  s = mmu_read_long(cpu->pc);
+  s = bus_read_long(cpu->pc);
   cpu->pc += 4;
   d = ea_read_long(cpu, op&0x3f, 1);
   r = s&d;
@@ -87,17 +87,17 @@ static struct cprint *andi_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "ANDI.B");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size)&0xff);
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size)&0xff);
     ret->size += 2;
     break;
   case 1:
     strcpy(ret->instr, "ANDI.W");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size));
     ret->size += 2;
     break;
   case 2:
     strcpy(ret->instr, "ANDI.L");
-    sprintf(ret->data, "#$%x,", mmu_read_long_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_long_print(addr+ret->size));
     ret->size += 4;
     break;
   }

--- a/cpu/andi_to_ccr.c
+++ b/cpu/andi_to_ccr.c
@@ -11,7 +11,7 @@ static void andi_to_ccr(struct cpu *cpu, WORD op)
   ENTER;
 
   ADD_CYCLE(20);
-  d = mmu_read_word(cpu->pc)&0x1f;
+  d = bus_read_word(cpu->pc)&0x1f;
   cpu->pc += 2;
   sr = cpu->sr;
   sr = (sr&0xff00)|((sr&0xff)&d);
@@ -25,7 +25,7 @@ static struct cprint *andi_to_ccr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "ANDI");
-  sprintf(ret->data, "#$%x,CCR", mmu_read_word_print(addr+ret->size)&0xff);
+  sprintf(ret->data, "#$%x,CCR", bus_read_word_print(addr+ret->size)&0xff);
   ret->size += 2;
   
   return ret;

--- a/cpu/andi_to_sr.c
+++ b/cpu/andi_to_sr.c
@@ -11,7 +11,7 @@ static void andi_to_sr(struct cpu *cpu, WORD op)
 
   if(cpu->sr&0x2000) {
     ADD_CYCLE(20);
-    d = mmu_read_word(cpu->pc);
+    d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr&d);
     cpu->tracedelay = 1;
@@ -27,7 +27,7 @@ static struct cprint *andi_to_sr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "ANDI");
-  sprintf(ret->data, "#$%x,SR", mmu_read_word_print(addr+ret->size));
+  sprintf(ret->data, "#$%x,SR", bus_read_word_print(addr+ret->size));
   ret->size += 2;
   
   return ret;

--- a/cpu/bcc.c
+++ b/cpu/bcc.c
@@ -13,7 +13,7 @@ void bcc(struct cpu *cpu, WORD op)
   w = 0;
   o = (SLONG)(SBYTE)(op&0xff);
   if(!o) {
-    o = mmu_read_word(cpu->pc);
+    o = bus_read_word(cpu->pc);
     if(o&0x8000) o |= 0xffff0000;
     o -= 2;
     cpu->pc += 2;
@@ -27,7 +27,7 @@ void bcc(struct cpu *cpu, WORD op)
   case 1: /* BSR */
     ADD_CYCLE(18);
     cpu->a[7] -= 4;
-    mmu_write_long(cpu->a[7], cpu->pc);
+    bus_write_long(cpu->a[7], cpu->pc);
     cpu->pc += o;
     return;
   case 2: /* BHI */
@@ -178,7 +178,7 @@ static struct cprint *bcc_print(LONG addr, WORD op)
     s = 1;
   } else {
     s = 0;
-    a = mmu_read_word_print(addr+ret->size);
+    a = bus_read_word_print(addr+ret->size);
     if(a&0x8000) a |= 0xffff0000;
   }
 

--- a/cpu/bchg.c
+++ b/cpu/bchg.c
@@ -8,7 +8,7 @@ static void bchg_i(struct cpu *cpu, int mode)
 {
   BYTE b,d;
 
-  b = (BYTE)mmu_read_word(cpu->pc)&0xff;
+  b = (BYTE)bus_read_word(cpu->pc)&0xff;
   b &= 31;
   cpu->pc += 2;
   if(mode&0x38) {
@@ -67,7 +67,7 @@ static struct cprint *bchg_print(LONG addr, WORD op)
 
   switch((op&0x100)>>8) {
   case 0:
-    b = mmu_read_word_print(addr+ret->size)&0x1f;
+    b = bus_read_word_print(addr+ret->size)&0x1f;
     ret->size += 2;
     if(op&0x38) {
       b &= 7;

--- a/cpu/bclr.c
+++ b/cpu/bclr.c
@@ -8,7 +8,7 @@ static void bclr_i(struct cpu *cpu, int mode)
 {
   BYTE b,d;
 
-  b = (BYTE)mmu_read_word(cpu->pc)&0xff;
+  b = (BYTE)bus_read_word(cpu->pc)&0xff;
   b &= 31;
   cpu->pc += 2;
   if(mode&0x38) {
@@ -67,7 +67,7 @@ static struct cprint *bclr_print(LONG addr, WORD op)
 
   switch((op&0x100)>>8) {
   case 0:
-    b = mmu_read_word_print(addr+ret->size)&0x1f;
+    b = bus_read_word_print(addr+ret->size)&0x1f;
     ret->size += 2;
     if(op&0x38) {
       b &= 7;

--- a/cpu/bset.c
+++ b/cpu/bset.c
@@ -8,7 +8,7 @@ static void bset_i(struct cpu *cpu, int mode)
 {
   BYTE b,d;
 
-  b = (BYTE)mmu_read_word(cpu->pc)&0xff;
+  b = (BYTE)bus_read_word(cpu->pc)&0xff;
   b &= 31;
   cpu->pc += 2;
   if(mode&0x38) {
@@ -67,7 +67,7 @@ static struct cprint *bset_print(LONG addr, WORD op)
 
   switch((op&0x100)>>8) {
   case 0:
-    b = mmu_read_word_print(addr+ret->size)&0x1f;
+    b = bus_read_word_print(addr+ret->size)&0x1f;
     ret->size += 2;
     if(op&0x38) {
       b &= 7;

--- a/cpu/btst.c
+++ b/cpu/btst.c
@@ -8,7 +8,7 @@ static void btst_i(struct cpu *cpu, int mode)
 {
   BYTE b,d;
 
-  b = (BYTE)mmu_read_word(cpu->pc)&0xff;
+  b = (BYTE)bus_read_word(cpu->pc)&0xff;
   b &= 31;
   cpu->pc += 2;
   if(mode&0x38) {
@@ -59,7 +59,7 @@ static struct cprint *btst_print(LONG addr, WORD op)
 
   switch((op&0x100)>>8) {
   case 0:
-    b = mmu_read_word_print(addr+ret->size)&0x1f;
+    b = bus_read_word_print(addr+ret->size)&0x1f;
     ret->size += 2;
     if(op&0x38) {
       b &= 7;

--- a/cpu/cmpi.c
+++ b/cpu/cmpi.c
@@ -9,7 +9,7 @@ static void cmpi_b(struct cpu *cpu, int mode)
   BYTE i,e,r;
 
   ADD_CYCLE(8);
-  i = mmu_read_word(cpu->pc)&0xff;
+  i = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   e = ea_read_byte(cpu, mode, 0);
 
@@ -22,7 +22,7 @@ static void cmpi_w(struct cpu *cpu, int mode)
   WORD i,e,r;
 
   ADD_CYCLE(8);
-  i = mmu_read_word(cpu->pc);
+  i = bus_read_word(cpu->pc);
   cpu->pc += 2;
   e = ea_read_word(cpu, mode, 0);
 
@@ -37,7 +37,7 @@ static void cmpi_l(struct cpu *cpu, int mode)
   if(!(mode&0x38)) {
       ADD_CYCLE(14);
   }
-  i = mmu_read_long(cpu->pc);
+  i = bus_read_long(cpu->pc);
   cpu->pc += 4;
   e = ea_read_long(cpu, mode, 0);
   
@@ -74,17 +74,17 @@ static struct cprint *cmpi_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "CMPI.B");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size)&0xff);
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size)&0xff);
     ret->size += 2;
     break;
   case 1:
     strcpy(ret->instr, "CMPI.W");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size));
     ret->size += 2;
     break;
   case 2:
     strcpy(ret->instr, "CMPI.L");
-    sprintf(ret->data, "#$%x,", mmu_read_long_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_long_print(addr+ret->size));
     ret->size += 4;
     break;
   }

--- a/cpu/cmpm.c
+++ b/cpu/cmpm.c
@@ -11,12 +11,12 @@ static void cmpm_b(struct cpu *cpu, WORD op)
   rx = (op&0xe00)>>9;
   ry = op&0x7;
   
-  s = mmu_read_byte(cpu->a[ry]);
+  s = bus_read_byte(cpu->a[ry]);
   if(ry == 7)
     cpu->a[ry] += 2;
   else
     cpu->a[ry] += 1;
-  d = mmu_read_byte(cpu->a[rx]);
+  d = bus_read_byte(cpu->a[rx]);
   if(rx == 7)
     cpu->a[rx] += 2;
   else
@@ -35,9 +35,9 @@ static void cmpm_w(struct cpu *cpu, WORD op)
   rx = (op&0xe00)>>9;
   ry = op&0x7;
   
-  s = mmu_read_word(cpu->a[ry]);
+  s = bus_read_word(cpu->a[ry]);
   cpu->a[ry] += 2;
-  d = mmu_read_word(cpu->a[rx]);
+  d = bus_read_word(cpu->a[rx]);
   cpu->a[rx] += 2;
   r = d-s;
   
@@ -53,9 +53,9 @@ static void cmpm_l(struct cpu *cpu, WORD op)
   rx = (op&0xe00)>>9;
   ry = op&0x7;
   
-  s = mmu_read_long(cpu->a[ry]);
+  s = bus_read_long(cpu->a[ry]);
   cpu->a[ry] += 4;
-  d = mmu_read_long(cpu->a[rx]);
+  d = bus_read_long(cpu->a[rx]);
   cpu->a[rx] += 4;
   r = d-s;
   

--- a/cpu/dbcc.c
+++ b/cpu/dbcc.c
@@ -11,7 +11,7 @@ void dbcc(struct cpu *cpu, WORD op)
   ENTER;
   
   r = op&7;
-  o = mmu_read_word(cpu->pc);
+  o = bus_read_word(cpu->pc);
   if(o&0x8000) o |= 0xffff0000;
   o -= 2;
   cpu->pc += 2;
@@ -128,7 +128,7 @@ static struct cprint *dbcc_print(LONG addr, WORD op)
 
   ret = cprint_alloc(addr);
 
-  a = mmu_read_word_print(addr+ret->size);
+  a = bus_read_word_print(addr+ret->size);
   if(a&0x8000) a |= 0xffff0000;
 
   a += addr+ret->size;

--- a/cpu/ea.c
+++ b/cpu/ea.c
@@ -88,7 +88,7 @@ static LONG ea_addr_101(struct cpu *cpu, int reg)
 {
   int o;
 
-  o = mmu_read_word(cpu->pc);
+  o = bus_read_word(cpu->pc);
   if(o&0x8000) o |= 0xffff0000;
 
   if(!rmw) {
@@ -101,7 +101,7 @@ static LONG ea_addr_110(struct cpu *cpu, int reg)
 {
   int d,o,r,a,rs;
 
-  d = mmu_read_word(cpu->pc);
+  d = bus_read_word(cpu->pc);
   if(!rmw) {
     cpu->pc += 2;
   }
@@ -129,7 +129,7 @@ static LONG ea_addr_111_pcxn(struct cpu *cpu)
 {
   int d,o,r,a,rs;
 
-  d = mmu_read_word(cpu->pc);
+  d = bus_read_word(cpu->pc);
   cpu->pc += 2;
   a = d&0x8000;
   r = (d&0x7000)>>12;
@@ -158,7 +158,7 @@ static LONG ea_addr_111(struct cpu *cpu, int reg)
   switch(reg) {
   case 0:
     ADD_CYCLE_EA(8);
-    a = mmu_read_word(cpu->pc);
+    a = bus_read_word(cpu->pc);
     if(a&0x8000) a |= 0xffff0000;
     if(!rmw) {
       cpu->pc += 2;
@@ -166,14 +166,14 @@ static LONG ea_addr_111(struct cpu *cpu, int reg)
     return a;
   case 1:
     ADD_CYCLE_EA(12);
-    a = mmu_read_long(cpu->pc);
+    a = bus_read_long(cpu->pc);
     if(!rmw) {
       cpu->pc += 4;
     }
     return a;
   case 2:
     ADD_CYCLE_EA(8);
-    a = mmu_read_word(cpu->pc);
+    a = bus_read_word(cpu->pc);
     if(a&0x8000) a |= 0xffff0000;
     cpu->pc += 2;
     return a+cpu->pc-2;
@@ -232,7 +232,7 @@ BYTE ea_read_byte(struct cpu *cpu, int mode, int noupdate)
   case 7:
     if((mode&0x7) == 4) {
       ADD_CYCLE_EA(4);
-      i = mmu_read_word(cpu->pc)&0xff;
+      i = bus_read_word(cpu->pc)&0xff;
       cpu->pc += 2;
       rmw = 0;
       return i;
@@ -244,7 +244,7 @@ BYTE ea_read_byte(struct cpu *cpu, int mode, int noupdate)
     addr = 0;
   }
   rmw = 0;
-  value = mmu_read_byte(addr);
+  value = bus_read_byte(addr);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -291,7 +291,7 @@ WORD ea_read_word(struct cpu *cpu, int mode, int noupdate)
   case 7:
     if((mode&0x7) == 4) {
       ADD_CYCLE_EA(4);
-      i = mmu_read_word(cpu->pc);
+      i = bus_read_word(cpu->pc);
       cpu->pc += 2;
       rmw = 0;
       return i;
@@ -303,7 +303,7 @@ WORD ea_read_word(struct cpu *cpu, int mode, int noupdate)
     addr = 0;
   }
   rmw = 0;
-  value = mmu_read_word(addr);
+  value = bus_read_word(addr);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -350,7 +350,7 @@ LONG ea_read_long(struct cpu *cpu, int mode, int noupdate)
   case 7:
     if((mode&0x7) == 4) {
       ADD_CYCLE_EA(8);
-      i = mmu_read_long(cpu->pc);
+      i = bus_read_long(cpu->pc);
       cpu->pc += 4;
       rmw = 0;
       return i;
@@ -363,7 +363,7 @@ LONG ea_read_long(struct cpu *cpu, int mode, int noupdate)
     addr = 0;
   }
   rmw = 0;
-  value = mmu_read_long(addr);
+  value = bus_read_long(addr);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -416,7 +416,7 @@ void ea_write_byte(struct cpu *cpu, int mode, BYTE data)
     cpu_prefetch();
     ea_clear_prefetch_before_write();
   }
-  mmu_write_byte(addr, data);
+  bus_write_byte(addr, data);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -468,7 +468,7 @@ void ea_write_word(struct cpu *cpu, int mode, WORD data)
     cpu_prefetch();
     ea_clear_prefetch_before_write();
   }
-  mmu_write_word(addr, data);
+  bus_write_word(addr, data);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -521,7 +521,7 @@ void ea_write_long(struct cpu *cpu, int mode, LONG data)
     cpu_prefetch();
     ea_clear_prefetch_before_write();
   }
-  mmu_write_long(addr, data);
+  bus_write_long(addr, data);
   if(cpu_full_stacked_exception_pending() && (((mode&0x38)>>3) == 3 || ((mode&0x38)>>3) == 4)) {
     cpu->a[mode&0x7] -= last_register_change;
   }
@@ -580,7 +580,7 @@ static void ea_print_111(struct cprint *cprint, int mode, int size)
 
   switch(mode&0x7) {
   case 0:
-    a = mmu_read_word_print(addr);
+    a = bus_read_word_print(addr);
     if(a&0x8000) a |= 0xffff0000;
     cprint_set_label(a, NULL);
     if(cprint_find_label(a)) {
@@ -591,7 +591,7 @@ static void ea_print_111(struct cprint *cprint, int mode, int size)
     cprint->size += 2;
     return;
   case 1:
-    a = mmu_read_long_print(addr);
+    a = bus_read_long_print(addr);
     cprint_set_label(a, NULL);
     if(cprint_find_label(a)) {
       sprintf(str, "%s%s", str, cprint_find_label(a));
@@ -601,7 +601,7 @@ static void ea_print_111(struct cprint *cprint, int mode, int size)
     cprint->size += 4;
     return;
   case 2:
-    a = mmu_read_word_print(addr);
+    a = bus_read_word_print(addr);
     if(a&0x8000) a |= 0xffff0000;
     a += addr;
     cprint_set_label(a, NULL);
@@ -613,7 +613,7 @@ static void ea_print_111(struct cprint *cprint, int mode, int size)
     cprint->size += 2;
     return;
   case 3:
-    a = mmu_read_word_print(addr);
+    a = bus_read_word_print(addr);
     d = a&0x8000;
     r = (a&0x7000)>>12;
     l = a&0x800;
@@ -623,15 +623,15 @@ static void ea_print_111(struct cprint *cprint, int mode, int size)
     return;
   case 4:
     if(size == 0) {
-      sprintf(str, "%s#$%x", str, mmu_read_word_print(addr)&0xff);
+      sprintf(str, "%s#$%x", str, bus_read_word_print(addr)&0xff);
       cprint->size += 2;
       return;
     } else if(size == 1) {
-      sprintf(str, "%s#$%x", str, mmu_read_word_print(addr));
+      sprintf(str, "%s#$%x", str, bus_read_word_print(addr));
       cprint->size += 2;
       return;
     } else {
-      sprintf(str, "%s#$%x", str, mmu_read_long_print(addr));
+      sprintf(str, "%s#$%x", str, bus_read_long_print(addr));
       cprint->size += 4;
       return;
     }
@@ -663,7 +663,7 @@ void ea_print(struct cprint *cprint, int mode, int size)
     sprintf(str, "%s-(A%d)", str, mode&0x7);
     return;
   case 5:
-    o = mmu_read_word_print(addr);
+    o = bus_read_word_print(addr);
     if(o&0x8000) o |= 0xffff0000;
     if(o > 127)
       sprintf(str, "%s$%x(A%d)", str, o, mode&0x7);
@@ -672,15 +672,15 @@ void ea_print(struct cprint *cprint, int mode, int size)
     cprint->size += 2;
     return;
   case 6:
-    o = mmu_read_byte_print(addr+1)&0xff;
+    o = bus_read_byte_print(addr+1)&0xff;
     if(o&0x80) o |= 0xffffff00;
     sprintf(str, "%s%d(A%d,%c%d.%c)",
 	    str, 
 	    o,
 	    mode&0x7,
-	    (mmu_read_byte_print(addr)&0x80)?'A':'D',
-	    (mmu_read_byte_print(addr)>>4)&0x7,
-	    (mmu_read_byte_print(addr)&0x8)?'L':'W');
+	    (bus_read_byte_print(addr)&0x80)?'A':'D',
+	    (bus_read_byte_print(addr)>>4)&0x7,
+	    (bus_read_byte_print(addr)&0x8)?'L':'W');
     cprint->size += 2;
     return;
   case 7:

--- a/cpu/eori.c
+++ b/cpu/eori.c
@@ -13,7 +13,7 @@ static void eori_b(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc)&0xff;
+  s = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   d = ea_read_byte(cpu, op&0x3f, 1);
   r = s^d;
@@ -31,7 +31,7 @@ static void eori_w(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc);
+  s = bus_read_word(cpu->pc);
   cpu->pc += 2;
   d = ea_read_word(cpu, op&0x3f, 1);
   r = s^d;
@@ -49,7 +49,7 @@ static void eori_l(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(16);
   }
-  s = mmu_read_long(cpu->pc);
+  s = bus_read_long(cpu->pc);
   cpu->pc += 4;
   d = ea_read_long(cpu, op&0x3f, 1);
   r = s^d;
@@ -87,17 +87,17 @@ static struct cprint *eori_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "EORI.B");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size)&0xff);
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size)&0xff);
     ret->size += 2;
     break;
   case 1:
     strcpy(ret->instr, "EORI.W");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size));
     ret->size += 2;
     break;
   case 2:
     strcpy(ret->instr, "EORI.L");
-    sprintf(ret->data, "#$%x,", mmu_read_long_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_long_print(addr+ret->size));
     ret->size += 4;
     break;
   }

--- a/cpu/eori_to_ccr.c
+++ b/cpu/eori_to_ccr.c
@@ -10,7 +10,7 @@ static void eori_to_ccr(struct cpu *cpu, WORD op)
   ENTER;
 
   ADD_CYCLE(20);
-  d = mmu_read_word(cpu->pc)&0x1f;
+  d = bus_read_word(cpu->pc)&0x1f;
   cpu->pc += 2;
   cpu_set_sr(cpu->sr^d);
 }
@@ -22,7 +22,7 @@ static struct cprint *eori_to_ccr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "EORI");
-  sprintf(ret->data, "#$%x,CCR", mmu_read_word_print(addr+ret->size)&0xff);
+  sprintf(ret->data, "#$%x,CCR", bus_read_word_print(addr+ret->size)&0xff);
   ret->size += 2;
   
   return ret;

--- a/cpu/eori_to_sr.c
+++ b/cpu/eori_to_sr.c
@@ -11,7 +11,7 @@ static void eori_to_sr(struct cpu *cpu, WORD op)
 
   if(cpu->sr&0x2000) {
     ADD_CYCLE(20);
-    d = mmu_read_word(cpu->pc);
+    d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr^d);
     cpu->tracedelay = 1;
@@ -27,7 +27,7 @@ static struct cprint *eori_to_sr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "EORI");
-  sprintf(ret->data, "#$%x,SR", mmu_read_word_print(addr+ret->size));
+  sprintf(ret->data, "#$%x,SR", bus_read_word_print(addr+ret->size));
   ret->size += 2;
   
   return ret;

--- a/cpu/jsr.c
+++ b/cpu/jsr.c
@@ -15,7 +15,7 @@ static void jsr(struct cpu *cpu, WORD op)
   newpc = ea_get_addr(cpu, op&0x3f);
   cpu->a[7] -= 4;
   cpu_prefetch();
-  mmu_write_long(cpu->a[7], cpu->pc);
+  bus_write_long(cpu->a[7], cpu->pc);
   cpu->pc = newpc;
   if(newpc != cpu->a[7] && newpc != (cpu->a[7]+2)) {
     cpu_clear_prefetch();

--- a/cpu/link.c
+++ b/cpu/link.c
@@ -10,7 +10,7 @@ static void link(struct cpu *cpu, WORD op)
 
   ENTER;
 
-  d = mmu_read_word(cpu->pc);
+  d = bus_read_word(cpu->pc);
   cpu->pc += 2;
   if(d&0x8000) d |= 0xffff0000;
   
@@ -18,7 +18,7 @@ static void link(struct cpu *cpu, WORD op)
 
   cpu->a[7] -= 4;
   cpu_prefetch();
-  mmu_write_long(cpu->a[7], cpu->a[r]);
+  bus_write_long(cpu->a[7], cpu->a[r]);
   cpu->a[r] = cpu->a[7];
   cpu->a[7] += d;
 
@@ -32,7 +32,7 @@ static struct cprint *link_print(LONG addr, WORD op)
 
   ret = cprint_alloc(addr);
 
-  d = mmu_read_word_print(addr+ret->size);
+  d = bus_read_word_print(addr+ret->size);
   if(d&0x8000) d |= 0xffff0000;
   ret->size += 2;
   

--- a/cpu/movem.c
+++ b/cpu/movem.c
@@ -42,7 +42,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
   if(op&0x400) {
     for(i=0;i<8;i++) {
       if(rmask&(1<<i)) {
-	d = mmu_read_word(a+cnt*2);
+	d = bus_read_word(a+cnt*2);
 	if(d&0x8000) d |= 0xffff0000;
 	cpu->d[i] = d;
 	cnt++;
@@ -52,7 +52,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
     }
     for(i=0;i<8;i++) {
       if(rmask&(1<<(i+8))) {
-	d = mmu_read_word(a+cnt*2);
+	d = bus_read_word(a+cnt*2);
 	if(d&0x8000) d |= 0xffff0000;
 	cpu->a[i] = d;
 	cnt++;
@@ -67,7 +67,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(15-(i+8)))) {
 	  d = cpu->a[i]&0xffff;
           cpu_prefetch();
-	  mmu_write_word(a-cnt*2, d);
+	  bus_write_word(a-cnt*2, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+4);
 	  cpu->icycle = 0;
@@ -77,7 +77,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(15-i))) {
 	  d = cpu->d[i]&0xffff;
           cpu_prefetch();
-	  mmu_write_word(a-cnt*2, d);
+	  bus_write_word(a-cnt*2, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+4);
 	  cpu->icycle = 0;
@@ -89,7 +89,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<i)) {
 	  d = cpu->d[i]&0xffff;
           cpu_prefetch();
-	  mmu_write_word(a+cnt*2, d);
+	  bus_write_word(a+cnt*2, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+4);
 	  cpu->icycle = 0;
@@ -99,7 +99,7 @@ static void movem_w(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(i+8))) {
 	  d = cpu->a[i]&0xffff;
           cpu_prefetch();
-	  mmu_write_word(a+cnt*2, d);
+	  bus_write_word(a+cnt*2, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+4);
 	  cpu->icycle = 0;
@@ -148,7 +148,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
   if(op&0x400) {
     for(i=0;i<8;i++) {
       if(rmask&(1<<i)) {
-	d = mmu_read_long(a+cnt*4);
+	d = bus_read_long(a+cnt*4);
 	cpu->d[i] = d;
 	cnt++;
 	cpu_do_cycle(cpu->icycle+8);
@@ -157,7 +157,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
     }
     for(i=0;i<8;i++) {
       if(rmask&(1<<(i+8))) {
-	d = mmu_read_long(a+cnt*4);
+	d = bus_read_long(a+cnt*4);
 	cpu->a[i] = d;
 	cnt++;
 	cpu_do_cycle(cpu->icycle+8);
@@ -171,7 +171,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(15-(i+8)))) {
 	  d = cpu->a[i];
           cpu_prefetch();
-	  mmu_write_long(a-cnt*4, d);
+	  bus_write_long(a-cnt*4, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+8);
 	  cpu->icycle = 0;
@@ -181,7 +181,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(15-i))) {
 	  d = cpu->d[i];
           cpu_prefetch();
-	  mmu_write_long(a-cnt*4, d);
+	  bus_write_long(a-cnt*4, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+8);
 	  cpu->icycle = 0;
@@ -193,7 +193,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<i)) {
 	  d = cpu->d[i];
           cpu_prefetch();
-	  mmu_write_long(a+cnt*4, d);
+	  bus_write_long(a+cnt*4, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+8);
 	  cpu->icycle = 0;
@@ -203,7 +203,7 @@ static void movem_l(struct cpu *cpu, WORD op, int rmask)
 	if(rmask&(1<<(i+8))) {
 	  d = cpu->a[i];
           cpu_prefetch();
-	  mmu_write_long(a+cnt*4, d);
+	  bus_write_long(a+cnt*4, d);
 	  cnt++;
 	  cpu_do_cycle(cpu->icycle+8);
 	  cpu->icycle = 0;
@@ -220,7 +220,7 @@ static void movem(struct cpu *cpu, WORD op)
 
   ENTER;
 
-  rmask = mmu_read_word(cpu->pc);
+  rmask = bus_read_word(cpu->pc);
   cpu->pc += 2;
 
   switch((op&0x38)>>3) {
@@ -341,7 +341,7 @@ static struct cprint *movem_print(LONG addr, WORD op)
   
   ret = cprint_alloc(addr);
 
-  rmask = mmu_read_word_print(addr+ret->size);
+  rmask = bus_read_word_print(addr+ret->size);
   ret->size += 2;
   
   if(((op&0x38)>>3) == 4) {

--- a/cpu/movep.c
+++ b/cpu/movep.c
@@ -12,39 +12,39 @@ static void movep(struct cpu *cpu, WORD op)
 
   ar = op&0x7;
   dr = (op&0xe00)>>9;
-  a = mmu_read_word(cpu->pc);
+  a = bus_read_word(cpu->pc);
   if(a&0x8000) a |= 0xffff0000;
   a += cpu->a[ar];
   cpu->pc += 2;
     
   switch((op&0xc0)>>6) {
   case 0:
-    d = (mmu_read_byte(a)<<8)|mmu_read_byte(a+2);
+    d = (bus_read_byte(a)<<8)|bus_read_byte(a+2);
     cpu->d[dr] = (cpu->d[dr]&0xffff0000)|(d&0xffff);
     ADD_CYCLE(16);
     return;
   case 1:
-    d = ((mmu_read_byte(a)<<24)|
-	 (mmu_read_byte(a+2)<<16)|
-	 (mmu_read_byte(a+4)<<8)|
-	 (mmu_read_byte(a+6)));
+    d = ((bus_read_byte(a)<<24)|
+	 (bus_read_byte(a+2)<<16)|
+	 (bus_read_byte(a+4)<<8)|
+	 (bus_read_byte(a+6)));
     cpu->d[dr] = d;
     ADD_CYCLE(24);
     return;
   case 2:
     d = cpu->d[dr]&0xffff;
     cpu_prefetch();
-    mmu_write_byte(a, (BYTE)((d&0xff00)>>8));
-    mmu_write_byte(a+2, (BYTE)((d&0xff)));
+    bus_write_byte(a, (BYTE)((d&0xff00)>>8));
+    bus_write_byte(a+2, (BYTE)((d&0xff)));
     ADD_CYCLE(16);
     return;
   case 3:
     d = cpu->d[dr];
     cpu_prefetch();
-    mmu_write_byte(a, (BYTE)((d&0xff000000)>>24));
-    mmu_write_byte(a+2, (BYTE)((d&0xff0000)>>16));
-    mmu_write_byte(a+4, (BYTE)((d&0xff00)>>8));
-    mmu_write_byte(a+6, (BYTE)((d&0xff)));
+    bus_write_byte(a, (BYTE)((d&0xff000000)>>24));
+    bus_write_byte(a+2, (BYTE)((d&0xff0000)>>16));
+    bus_write_byte(a+4, (BYTE)((d&0xff00)>>8));
+    bus_write_byte(a+6, (BYTE)((d&0xff)));
     ADD_CYCLE(24);
     return;
   }
@@ -59,7 +59,7 @@ static struct cprint *movep_print(LONG addr, WORD op)
   
   ar = op&0x7;
   dr = (op&0xe00)>>9;
-  o = mmu_read_word(addr+ret->size);
+  o = bus_read_word(addr+ret->size);
   if(o&0x8000) o |= 0xffff0000;
   ret->size += 2;
 

--- a/cpu/ori.c
+++ b/cpu/ori.c
@@ -13,7 +13,7 @@ static void ori_b(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc)&0xff;
+  s = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   d = ea_read_byte(cpu, op&0x3f, 1);
   r = s|d;
@@ -31,7 +31,7 @@ static void ori_w(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(8);
   }
-  s = mmu_read_word(cpu->pc);
+  s = bus_read_word(cpu->pc);
   cpu->pc += 2;
   d = ea_read_word(cpu, op&0x3f, 1);
   r = s|d;
@@ -49,7 +49,7 @@ static void ori_l(struct cpu *cpu, WORD op)
   } else {
     ADD_CYCLE(16);
   }
-  s = mmu_read_long(cpu->pc);
+  s = bus_read_long(cpu->pc);
   cpu->pc += 4;
   d = ea_read_long(cpu, op&0x3f, 1);
   r = s|d;
@@ -87,17 +87,17 @@ static struct cprint *ori_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "ORI.B");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size)&0xff);
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size)&0xff);
     ret->size += 2;
     break;
   case 1:
     strcpy(ret->instr, "ORI.W");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size));
     ret->size += 2;
     break;
   case 2:
     strcpy(ret->instr, "ORI.L");
-    sprintf(ret->data, "#$%x,", mmu_read_long_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_long_print(addr+ret->size));
     ret->size += 4;
     break;
   }

--- a/cpu/ori_to_ccr.c
+++ b/cpu/ori_to_ccr.c
@@ -10,7 +10,7 @@ static void ori_to_ccr(struct cpu *cpu, WORD op)
   ENTER;
 
   ADD_CYCLE(20);
-  d = mmu_read_word(cpu->pc)&0x1f;
+  d = bus_read_word(cpu->pc)&0x1f;
   cpu->pc += 2;
   cpu_set_sr(cpu->sr|d);
 }
@@ -22,7 +22,7 @@ static struct cprint *ori_to_ccr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "ORI");
-  sprintf(ret->data, "#$%x,CCR", mmu_read_word_print(addr+ret->size)&0xff);
+  sprintf(ret->data, "#$%x,CCR", bus_read_word_print(addr+ret->size)&0xff);
   ret->size += 2;
   
   return ret;

--- a/cpu/ori_to_sr.c
+++ b/cpu/ori_to_sr.c
@@ -11,7 +11,7 @@ static void ori_to_sr(struct cpu *cpu, WORD op)
 
   if(cpu->sr&0x2000) {
     ADD_CYCLE(20);
-    d = mmu_read_word(cpu->pc);
+    d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr|d);
     cpu->tracedelay = 1;
@@ -27,7 +27,7 @@ static struct cprint *ori_to_sr_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "ORI");
-  sprintf(ret->data, "#$%x,SR", mmu_read_word_print(addr+ret->size));
+  sprintf(ret->data, "#$%x,SR", bus_read_word_print(addr+ret->size));
   ret->size += 2;
   
   return ret;

--- a/cpu/pea.c
+++ b/cpu/pea.c
@@ -11,7 +11,7 @@ static void pea(struct cpu *cpu, WORD op)
   a = ea_get_addr(cpu, op&0x3f);
   cpu->a[7] -= 4;
   cpu_prefetch();
-  mmu_write_long(cpu->a[7], a);
+  bus_write_long(cpu->a[7], a);
   // x(An,Dn) and x(PC,Dn) needs an extra 4 cycles due to internal workings of PEA and alignments in the ST
   if((op&0x38) == 0x30 || (op&0x3f) == 0x3b) {
     ADD_CYCLE(4);

--- a/cpu/rte.c
+++ b/cpu/rte.c
@@ -14,9 +14,9 @@ static void rte(struct cpu *cpu, WORD op)
 
   if(cpu->sr&0x2000) {
     ADD_CYCLE(20);
-    sr = mmu_read_word(cpu->a[7]);
+    sr = bus_read_word(cpu->a[7]);
     cpu->a[7] += 2;
-    pc = mmu_read_long(cpu->a[7]);
+    pc = bus_read_long(cpu->a[7]);
     cpu->a[7] += 4;
 #if EXTREME_EXCEPTION_DEBUG
     printf("DEBUG: %d Leaving interrupt [%08x / %04x => %08x / %04x]\n", cpu->cycle, cpu->pc, cpu->sr, pc, sr);

--- a/cpu/rtr.c
+++ b/cpu/rtr.c
@@ -10,9 +10,9 @@ static void rtr(struct cpu *cpu, WORD op)
   ENTER;
 
   ADD_CYCLE(20);
-  ccr = mmu_read_word(cpu->a[7]);
+  ccr = bus_read_word(cpu->a[7]);
   cpu->a[7] += 2;
-  cpu->pc = mmu_read_long(cpu->a[7]);
+  cpu->pc = bus_read_long(cpu->a[7]);
   cpu->a[7] += 4;
   cpu_set_sr((cpu->sr&0xffe0)|(ccr&0x1f));
 }

--- a/cpu/rts.c
+++ b/cpu/rts.c
@@ -7,7 +7,7 @@ static void rts(struct cpu *cpu, WORD op)
 {
   ENTER;
 
-  cpu->pc = mmu_read_long(cpu->a[7]);
+  cpu->pc = bus_read_long(cpu->a[7]);
   cpu->a[7] += 4;
   ADD_CYCLE(16);
 }

--- a/cpu/sbcd.c
+++ b/cpu/sbcd.c
@@ -17,12 +17,12 @@ static void sbcd(struct cpu *cpu, WORD op)
       cpu->a[ry] -= 2;
     else
       cpu->a[ry] -= 1;
-    sb = mmu_read_byte(cpu->a[ry]);
+    sb = bus_read_byte(cpu->a[ry]);
     if(rx == 7)
       cpu->a[rx] -= 2;
     else
       cpu->a[rx] -= 1;
-    db = mmu_read_byte(cpu->a[rx]);
+    db = bus_read_byte(cpu->a[rx]);
     s = 10*((sb&0xf0)>>4)+((sb&0xf));
     d = 10*((db&0xf0)>>4)+((db&0xf));
     r = d-s;
@@ -31,7 +31,7 @@ static void sbcd(struct cpu *cpu, WORD op)
     if(r&0xff) SETZ;
     rb = (r%10)|(((r/10)%10)<<4);
     cpu_prefetch();
-    mmu_write_byte(cpu->a[rx], rb);
+    bus_write_byte(cpu->a[rx], rb);
     ADD_CYCLE(18);
   } else {
     sb = cpu->d[ry]&0xff;

--- a/cpu/stop.c
+++ b/cpu/stop.c
@@ -9,7 +9,7 @@ static void stop(struct cpu *cpu, WORD op)
 
   if(cpu->sr&0x2000) {
     ADD_CYCLE(4);
-    cpu_set_sr(mmu_read_word(cpu->pc));
+    cpu_set_sr(bus_read_word(cpu->pc));
     cpu->pc += 2;
     cpu->stopped = 1;
   } else {
@@ -24,7 +24,7 @@ static struct cprint *stop_print(LONG addr, WORD op)
   ret = cprint_alloc(addr);
 
   strcpy(ret->instr, "STOP");
-  sprintf(ret->data, "#$%04x", mmu_read_word_print(addr+ret->size));
+  sprintf(ret->data, "#$%04x", bus_read_word_print(addr+ret->size));
   ret->size += 2;
   
   return ret;

--- a/cpu/subi.c
+++ b/cpu/subi.c
@@ -8,7 +8,7 @@ static void subi_b(struct cpu *cpu, WORD op)
 {
   BYTE s,d,r;
   
-  s = mmu_read_word(cpu->pc)&0xff;
+  s = bus_read_word(cpu->pc)&0xff;
   cpu->pc += 2;
   if(op&0x38) {
     ADD_CYCLE(12);
@@ -26,7 +26,7 @@ static void subi_w(struct cpu *cpu, WORD op)
 {
   WORD s,d,r;
   
-  s = mmu_read_word(cpu->pc);
+  s = bus_read_word(cpu->pc);
   cpu->pc += 2;
   if(op&0x38) {
     ADD_CYCLE(12);
@@ -44,7 +44,7 @@ static void subi_l(struct cpu *cpu, WORD op)
 {
   LONG s,d,r;
   
-  s = mmu_read_long(cpu->pc);
+  s = bus_read_long(cpu->pc);
   cpu->pc += 4;
   if(op&0x38) {
     ADD_CYCLE(20);
@@ -87,17 +87,17 @@ static struct cprint *subi_print(LONG addr, WORD op)
   switch(s) {
   case 0:
     strcpy(ret->instr, "SUBI.B");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size)&0xff);
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size)&0xff);
     ret->size += 2;
     break;
   case 1:
     strcpy(ret->instr, "SUBI.W");
-    sprintf(ret->data, "#$%x,", mmu_read_word_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_word_print(addr+ret->size));
     ret->size += 2;
     break;
   case 2:
     strcpy(ret->instr, "SUBI.L");
-    sprintf(ret->data, "#$%x,", mmu_read_long_print(addr+ret->size));
+    sprintf(ret->data, "#$%x,", bus_read_long_print(addr+ret->size));
     ret->size += 4;
     break;
   }

--- a/cpu/subx.c
+++ b/cpu/subx.c
@@ -17,16 +17,16 @@ static void subx_b(struct cpu *cpu, WORD op)
       cpu->a[ry] -= 2;
     else
       cpu->a[ry] -= 1;
-    s = mmu_read_byte(cpu->a[ry]);
+    s = bus_read_byte(cpu->a[ry]);
     if(rx == 7)
       cpu->a[rx] -= 2;
     else
       cpu->a[rx] -= 1;
-    d = mmu_read_byte(cpu->a[rx]);
+    d = bus_read_byte(cpu->a[rx]);
     r = d-s;
     if(CHKX) r -= 1;
     cpu_prefetch();
-    mmu_write_byte(cpu->a[rx], r);
+    bus_write_byte(cpu->a[rx], r);
     ADD_CYCLE(18);
   } else {
     s = cpu->d[ry]&0xff;
@@ -51,12 +51,12 @@ static void subx_w(struct cpu *cpu, WORD op)
 
   if(op&0x8) {
     cpu->a[ry] -= 2;
-    s = mmu_read_word(cpu->a[ry]);
+    s = bus_read_word(cpu->a[ry]);
     cpu->a[rx] -= 2;
-    d = mmu_read_word(cpu->a[rx]);
+    d = bus_read_word(cpu->a[rx]);
     r = d-s;
     if(CHKX) r -= 1;
-    mmu_write_word(cpu->a[rx], r);
+    bus_write_word(cpu->a[rx], r);
     ADD_CYCLE(18);
   } else {
     s = cpu->d[ry]&0xffff;
@@ -81,12 +81,12 @@ static void subx_l(struct cpu *cpu, WORD op)
 
   if(op&0x8) {
     cpu->a[ry] -= 4;
-    s = mmu_read_long(cpu->a[ry]);
+    s = bus_read_long(cpu->a[ry]);
     cpu->a[rx] -= 4;
-    d = mmu_read_long(cpu->a[rx]);
+    d = bus_read_long(cpu->a[rx]);
     r = d-s;
     if(CHKX) r -= 1;
-    mmu_write_long(cpu->a[rx], r);
+    bus_write_long(cpu->a[rx], r);
     ADD_CYCLE(30);
   } else {
     s = cpu->d[ry];

--- a/cpu/unlk.c
+++ b/cpu/unlk.c
@@ -12,7 +12,7 @@ static void unlk(struct cpu *cpu, WORD op)
   r = op&0x7;
 
   cpu->a[7] = cpu->a[r];
-  cpu->a[r] = mmu_read_long(cpu->a[7]);
+  cpu->a[r] = bus_read_long(cpu->a[7]);
   cpu->a[7] += 4;
 
   ADD_CYCLE(12);

--- a/debug/edit.c
+++ b/debug/edit.c
@@ -128,13 +128,13 @@ static int edit_do_setmem()
     return EDIT_FAILURE;
 
   if(bits == 8) {
-    mmu_write_byte(addr, value&0xff);
+    bus_write_byte(addr, value&0xff);
   }
   if(bits == 16) {
-    mmu_write_word(addr, value&0xffff);
+    bus_write_word(addr, value&0xffff);
   }
   if(bits == 32) {
-    mmu_write_long(addr, value);
+    bus_write_long(addr, value);
   }
   
   return EDIT_SUCCESS;

--- a/debug/layout.c
+++ b/debug/layout.c
@@ -60,21 +60,21 @@ void layout_draw_info(int lnum, int wnum)
 	    drawable((cpu->d[i]>>8)&0xff),
 	    drawable(cpu->d[i]&0xff),
 	    i, cpu->a[i],
-	    mmu_read_word_print(cpu->a[i]),
-	    mmu_read_word_print(cpu->a[i]+2),
-	    mmu_read_word_print(cpu->a[i]+4),
-	    mmu_read_word_print(cpu->a[i]+6),
-	    mmu_read_word_print(cpu->a[i]+8),
-	    drawable(mmu_read_byte_print(cpu->a[i])),
-	    drawable(mmu_read_byte_print(cpu->a[i]+1)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+2)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+3)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+4)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+5)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+6)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+7)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+8)),
-	    drawable(mmu_read_byte_print(cpu->a[i]+9))
+	    bus_read_word_print(cpu->a[i]),
+	    bus_read_word_print(cpu->a[i]+2),
+	    bus_read_word_print(cpu->a[i]+4),
+	    bus_read_word_print(cpu->a[i]+6),
+	    bus_read_word_print(cpu->a[i]+8),
+	    drawable(bus_read_byte_print(cpu->a[i])),
+	    drawable(bus_read_byte_print(cpu->a[i]+1)),
+	    drawable(bus_read_byte_print(cpu->a[i]+2)),
+	    drawable(bus_read_byte_print(cpu->a[i]+3)),
+	    drawable(bus_read_byte_print(cpu->a[i]+4)),
+	    drawable(bus_read_byte_print(cpu->a[i]+5)),
+	    drawable(bus_read_byte_print(cpu->a[i]+6)),
+	    drawable(bus_read_byte_print(cpu->a[i]+7)),
+	    drawable(bus_read_byte_print(cpu->a[i]+8)),
+	    drawable(bus_read_byte_print(cpu->a[i]+9))
 	    );
     draw_string(8, 9+8*(font+1)*i, font, text);
     lcnt++;
@@ -108,17 +108,17 @@ void layout_draw_info(int lnum, int wnum)
   for(i=0;i<MIN(10, rows-lcnt);i++) {
     sprintf(text, "m%d = %08X %04X %04X %04X %04X %04X %04X %04X %04X  ",
 	    i, win[i].addr,
-	    mmu_read_word_print(win[i].addr),
-	    mmu_read_word_print(win[i].addr+2),
-	    mmu_read_word_print(win[i].addr+4),
-	    mmu_read_word_print(win[i].addr+6),
-	    mmu_read_word_print(win[i].addr+8),
-	    mmu_read_word_print(win[i].addr+10),
-	    mmu_read_word_print(win[i].addr+12),
-	    mmu_read_word_print(win[i].addr+14));
+	    bus_read_word_print(win[i].addr),
+	    bus_read_word_print(win[i].addr+2),
+	    bus_read_word_print(win[i].addr+4),
+	    bus_read_word_print(win[i].addr+6),
+	    bus_read_word_print(win[i].addr+8),
+	    bus_read_word_print(win[i].addr+10),
+	    bus_read_word_print(win[i].addr+12),
+	    bus_read_word_print(win[i].addr+14));
     choff = strlen(text);
     for(j=0;j<16;j++) {
-      text[j+choff] = drawable(mmu_read_byte_print(win[i].addr+j));
+      text[j+choff] = drawable(bus_read_byte_print(win[i].addr+j));
     }
     text[choff+16] = '\0';
     draw_string(8, 9+8*(font+1)*(lcnt+i), font, text);
@@ -181,63 +181,63 @@ static char *layout_mem_line(LONG addr, int col)
     if(col == 78) {
       sprintf(text, "%06X %02X %04X %04X %04X %04X %04X %04X %04X %02X ",
 	      addr&0xffffff,
-	      mmu_read_byte_print(addr),
-	      mmu_read_word_print(addr+1),
-	      mmu_read_word_print(addr+3),
-	      mmu_read_word_print(addr+5),
-	      mmu_read_word_print(addr+7),
-	      mmu_read_word_print(addr+9),
-	      mmu_read_word_print(addr+11),
-	      mmu_read_word_print(addr+13),
-	      mmu_read_byte_print(addr+15));
+	      bus_read_byte_print(addr),
+	      bus_read_word_print(addr+1),
+	      bus_read_word_print(addr+3),
+	      bus_read_word_print(addr+5),
+	      bus_read_word_print(addr+7),
+	      bus_read_word_print(addr+9),
+	      bus_read_word_print(addr+11),
+	      bus_read_word_print(addr+13),
+	      bus_read_byte_print(addr+15));
       chcnt = 16;
     } else if(col == 53) {
       sprintf(text, "%06X %02X %04X %04X %04X %04X %04X %02X ",
 	      addr&0xffffff,
-	      mmu_read_byte_print(addr),
-	      mmu_read_word_print(addr+1),
-	      mmu_read_word_print(addr+3),
-	      mmu_read_word_print(addr+5),
-	      mmu_read_word_print(addr+7),
-	      mmu_read_word_print(addr+9),
-	      mmu_read_byte_print(addr+11));
+	      bus_read_byte_print(addr),
+	      bus_read_word_print(addr+1),
+	      bus_read_word_print(addr+3),
+	      bus_read_word_print(addr+5),
+	      bus_read_word_print(addr+7),
+	      bus_read_word_print(addr+9),
+	      bus_read_byte_print(addr+11));
       chcnt = 12;
     } else if(col == 23) {
       sprintf(text, "%06X %02X %04X %02X ",
 	      addr&0xffffff,
-	      mmu_read_byte_print(addr),
-	      mmu_read_word_print(addr+1),
-	      mmu_read_byte_print(addr+3));
+	      bus_read_byte_print(addr),
+	      bus_read_word_print(addr+1),
+	      bus_read_byte_print(addr+3));
       chcnt = 4;
     }
   } else {
     if(col == 78) {
       sprintf(text, "%06X %04X %04X %04X %04X %04X %04X %04X %04X  ",
 	      addr&0xffffff,
-	      mmu_read_word_print(addr),
-	      mmu_read_word_print(addr+2),
-	      mmu_read_word_print(addr+4),
-	      mmu_read_word_print(addr+6),
-	      mmu_read_word_print(addr+8),
-	      mmu_read_word_print(addr+10),
-	      mmu_read_word_print(addr+12),
-	      mmu_read_word_print(addr+14));
+	      bus_read_word_print(addr),
+	      bus_read_word_print(addr+2),
+	      bus_read_word_print(addr+4),
+	      bus_read_word_print(addr+6),
+	      bus_read_word_print(addr+8),
+	      bus_read_word_print(addr+10),
+	      bus_read_word_print(addr+12),
+	      bus_read_word_print(addr+14));
       chcnt = 16;
     } else if(col == 53) {
       sprintf(text, "%06X %04X %04X %04X %04X %04X %04X  ",
 	      addr&0xffffff,
-	      mmu_read_word_print(addr),
-	      mmu_read_word_print(addr+2),
-	      mmu_read_word_print(addr+4),
-	      mmu_read_word_print(addr+6),
-	      mmu_read_word_print(addr+8),
-	      mmu_read_word_print(addr+10));
+	      bus_read_word_print(addr),
+	      bus_read_word_print(addr+2),
+	      bus_read_word_print(addr+4),
+	      bus_read_word_print(addr+6),
+	      bus_read_word_print(addr+8),
+	      bus_read_word_print(addr+10));
       chcnt = 12;
     } else if(col == 23) {
       sprintf(text, "%06X %04X %04X  ",
 	      addr&0xffffff,
-	      mmu_read_word_print(addr),
-	      mmu_read_word_print(addr+2));
+	      bus_read_word_print(addr),
+	      bus_read_word_print(addr+2));
       chcnt = 4;
     }
   }
@@ -245,7 +245,7 @@ static char *layout_mem_line(LONG addr, int col)
   choff = strlen(text);
   
   for(i=0;i<chcnt;i++) {
-    text[i+choff] = drawable(mmu_read_byte_print(addr+i));
+    text[i+choff] = drawable(bus_read_byte_print(addr+i));
   }
   text[choff+chcnt] = '\0';
 

--- a/dma.c
+++ b/dma.c
@@ -145,11 +145,6 @@ WORD dma_read_word(LONG addr)
   return 0xffff;
 }
 
-LONG dma_read_long(LONG addr)
-{
-  return (dma_read_word(addr)<<16)|dma_read_word(addr+1);
-}
-
 void dma_write_byte(LONG addr, BYTE data)
 {
   TRACE("WriteByte: %06x %02x", addr, data);
@@ -197,12 +192,6 @@ void dma_write_word(LONG addr, WORD data)
   }
 }
 
-void dma_write_long(LONG addr, LONG data)
-{
-  dma_write_word(addr, (data&0xffff0000)>>16);
-  dma_write_word(addr+2, data&0xffff);
-}
-
 static int dma_state_collect(struct mmu_state *state)
 {
   state->size = 0;
@@ -224,10 +213,8 @@ void dma_init()
   dma->size = DMASIZE;
   dma->read_byte = dma_read_byte;
   dma->read_word = dma_read_word;
-  dma->read_long = dma_read_long;
   dma->write_byte = dma_write_byte;
   dma->write_word = dma_write_word;
-  dma->write_long = dma_write_long;
   dma->state_collect = dma_state_collect;
   dma->state_restore = dma_state_restore;
   dma->diagnostics = dma_diagnostics;

--- a/expr.y
+++ b/expr.y
@@ -57,9 +57,9 @@ expr:	VAL { $$ = $1; }
 	| expr '/' expr { $$ = $1 / $3; }
 	| expr '*' expr { $$ = $1 * $3; }
 	| '(' expr ')' { $$ = $2; }
-	| '[' expr ']' { $$ = mmu_read_long_print($2); }
-	| '[' expr ']' SIZEW { $$ = mmu_read_word_print($2); }
-	| '[' expr ']' SIZEB { $$ = mmu_read_byte_print($2); }
+	| '[' expr ']' { $$ = bus_read_long_print($2); }
+	| '[' expr ']' SIZEW { $$ = bus_read_word_print($2); }
+	| '[' expr ']' SIZEB { $$ = bus_read_byte_print($2); }
 	| expr EQ expr { $$ = ($1 == $3); }
 	| expr NE expr { $$ = ($1 != $3); }
 	| expr LT expr { $$ = ($1 < $3); }

--- a/floppy.c
+++ b/floppy.c
@@ -124,12 +124,12 @@ int floppy_write_track(LONG addr, int dma_count)
 
 int floppy_read_address(LONG addr)
 {
-  mmu_write_byte(addr, floppy[active_device].sel_trk);
-  mmu_write_byte(addr+1, floppy[active_device].sel_side);
-  mmu_write_byte(addr+2, floppy[active_device].sel_sec);
-  mmu_write_byte(addr+3, 2); /* 512 byte for now */
-  mmu_write_byte(addr+4, 0);
-  mmu_write_byte(addr+5, 0);
+  bus_write_byte(addr, floppy[active_device].sel_trk);
+  bus_write_byte(addr+1, floppy[active_device].sel_side);
+  bus_write_byte(addr+2, floppy[active_device].sel_sec);
+  bus_write_byte(addr+3, 2); /* 512 byte for now */
+  bus_write_byte(addr+4, 0);
+  bus_write_byte(addr+5, 0);
   return 0;
 }
 

--- a/floppy_msa.c
+++ b/floppy_msa.c
@@ -25,7 +25,7 @@ static int read_sector(struct floppy *fl, int track, int side, int sector, LONG 
     /* Check if we're trying to read outside floppy data */
     if((pos+i*SECSIZE) >= (image->raw_data_size-SECSIZE)) return FLOPPY_ERROR;
     for(j=0;j<SECSIZE;j++) {
-      mmu_write_byte(addr+i*SECSIZE+j, image->raw_data[pos+i*SECSIZE+j]);
+      bus_write_byte(addr+i*SECSIZE+j, image->raw_data[pos+i*SECSIZE+j]);
     }
   }
   

--- a/floppy_st.c
+++ b/floppy_st.c
@@ -27,7 +27,7 @@ static int read_sector(struct floppy *fl, int track, int side, int sector, LONG 
     /* Check if we're trying to read outside floppy data */
     if((pos+i*SECSIZE) >= (image->raw_data_size-SECSIZE)) return FLOPPY_ERROR;
     for(j=0;j<SECSIZE;j++) {
-      mmu_write_byte(addr+i*SECSIZE+j, image->raw_data[pos+i*SECSIZE+j]);
+      bus_write_byte(addr+i*SECSIZE+j, image->raw_data[pos+i*SECSIZE+j]);
     }
   }
   
@@ -51,7 +51,7 @@ static int write_sector(struct floppy *fl, int track, int side, int sector, LONG
   for(i=0;i<count;i++) {
     if((pos+i*SECSIZE) >= (image->raw_data_size-SECSIZE)) return FLOPPY_ERROR;
     for(j=0;j<SECSIZE;j++) {
-      image->raw_data[pos+i*SECSIZE+j] = mmu_read_byte(addr+i*SECSIZE+j);
+      image->raw_data[pos+i*SECSIZE+j] = bus_read_byte(addr+i*SECSIZE+j);
     }
     save_file(fl, pos+i*SECSIZE);
   }

--- a/floppy_stx.c
+++ b/floppy_stx.c
@@ -94,7 +94,7 @@ static int read_sector(struct floppy *fl, int track, int side, int sector, LONG 
       if(track_sectors[sec_num].is_fuzzy) {
         data = (data&fuzzy_mask[j])|(rand()&~fuzzy_mask[j]);
       }
-      mmu_write_byte(dst_pos, data);
+      bus_write_byte(dst_pos, data);
       dst_pos++;
     }
   }
@@ -137,7 +137,7 @@ static int read_track(struct floppy *fl, int track_num, int side, LONG addr, int
   }
   
   for(i=0;i<size;i++) {
-    mmu_write_byte(addr + i, track->track_data[i]);
+    bus_write_byte(addr + i, track->track_data[i]);
   }
   return FLOPPY_OK;
 }

--- a/hdc.c
+++ b/hdc.c
@@ -43,7 +43,7 @@ void hdc_read_sectors(LONG addr, LONG block, BYTE sectors)
   }
   TRACE("Read sectors: Addr: %06x  Block %06x  Sectors: %d", addr, block, sectors);
   for(i=0;i<SECSIZE*sectors;i++) {
-    mmu_write_byte(addr+i, buffer[i]);
+    bus_write_byte(addr+i, buffer[i]);
   }
 }
 
@@ -56,7 +56,7 @@ void hdc_write_sectors(LONG addr, LONG block, BYTE sectors)
 
   TRACE("Write sectors: Addr: %06x  Block %06x  Sectors: %d", addr, block, sectors);
   for(i=0;i<SECSIZE*sectors;i++) {
-    buffer[i] = mmu_read_byte(addr+i);
+    buffer[i] = bus_read_byte(addr+i);
   }
 
   fseek(fp, block * SECSIZE, SEEK_SET);

--- a/mfp.c
+++ b/mfp.c
@@ -132,14 +132,6 @@ static WORD mfp_read_word(LONG addr)
   return (mfp_read_byte(addr)<<8)|mfp_read_byte(addr+1);
 }
 
-static LONG mfp_read_long(LONG addr)
-{
-  return ((mfp_read_byte(addr)<<24)|
-       (mfp_read_byte(addr+1)<<16)|
-       (mfp_read_byte(addr+2)<<8)|
-       (mfp_read_byte(addr+3)));
-}
-
 static void mfp_write_byte(LONG addr, BYTE data)
 {
   int r;
@@ -195,14 +187,6 @@ static void mfp_write_word(LONG addr, WORD data)
 {
   mfp_write_byte(addr, (data&0xff00)>>8);
   mfp_write_byte(addr+1, (data&0xff));
-}
-
-static void mfp_write_long(LONG addr, LONG data)
-{
-  mfp_write_byte(addr, (data&0xff000000)>>24);
-  mfp_write_byte(addr+1, (data&0xff0000)>>16);
-  mfp_write_byte(addr+2, (data&0xff00)>>8);
-  mfp_write_byte(addr+3, (data&0xff));
 }
 
 static int mfp_state_collect(struct mmu_state *state)
@@ -263,10 +247,8 @@ void mfp_init()
   mfp->size = MFPSIZE;
   mfp->read_byte = mfp_read_byte;
   mfp->read_word = mfp_read_word;
-  mfp->read_long = mfp_read_long;
   mfp->write_byte = mfp_write_byte;
   mfp->write_word = mfp_write_word;
-  mfp->write_long = mfp_write_long;
   mfp->state_collect = mfp_state_collect;
   mfp->state_restore = mfp_state_restore;
   mfp->diagnostics = mfp_diagnostics;

--- a/midi.c
+++ b/midi.c
@@ -51,14 +51,6 @@ static WORD midi_read_word(LONG addr)
   return (midi_read_byte(addr)<<8)|midi_read_byte(addr+1);
 }
 
-static LONG midi_read_long(LONG addr)
-{
-  return ((midi_read_byte(addr)<<24)|
-	  (midi_read_byte(addr+1)<<16)|
-	  (midi_read_byte(addr+2)<<8)|
-	  (midi_read_byte(addr+3)));
-}
-
 static void midi_write_byte(LONG addr, BYTE data)
 {
   switch(addr) {
@@ -75,14 +67,6 @@ static void midi_write_word(LONG addr, WORD data)
 {
   midi_write_byte(addr, (data&0xff00)>>8);
   midi_write_byte(addr+1, (data&0xff));
-}
-
-static void midi_write_long(LONG addr, LONG data)
-{
-  midi_write_byte(addr, (data&0xff000000)>>24);
-  midi_write_byte(addr+1, (data&0xff0000)>>16);
-  midi_write_byte(addr+2, (data&0xff00)>>8);
-  midi_write_byte(addr+3, (data&0xff));
 }
 
 static int midi_state_collect(struct mmu_state *state)
@@ -104,10 +88,8 @@ void midi_init()
   midi->size = MIDISIZE;
   midi->read_byte = midi_read_byte;
   midi->read_word = midi_read_word;
-  midi->read_long = midi_read_long;
   midi->write_byte = midi_write_byte;
   midi->write_word = midi_write_word;
-  midi->write_long = midi_write_long;
   midi->state_collect = midi_state_collect;
   midi->state_restore = midi_state_restore;
   midi->diagnostics = midi_diagnostics;

--- a/mmu.c
+++ b/mmu.c
@@ -251,7 +251,7 @@ void mmu_init()
  * and location
  */
 
-BYTE mmu_read_byte_print(LONG addr)
+BYTE bus_read_byte_print(LONG addr)
 {
   BYTE value;
   addr &= 0xffffff;
@@ -264,24 +264,24 @@ BYTE mmu_read_byte_print(LONG addr)
   return value;
 }
 
-WORD mmu_read_word_print(LONG addr)
+WORD bus_read_word_print(LONG addr)
 {
   BYTE low,high;
   addr &= 0xffffff;
 
-  high = mmu_read_byte_print(addr);
-  low = mmu_read_byte_print(addr+1);
+  high = bus_read_byte_print(addr);
+  low = bus_read_byte_print(addr+1);
 
   return (high<<8)|low;
 }
 
-LONG mmu_read_long_print(LONG addr)
+LONG bus_read_long_print(LONG addr)
 {
   WORD low,high;
   addr &= 0xffffff;
 
-  high = mmu_read_word_print(addr);
-  low = mmu_read_word_print(addr+2);
+  high = bus_read_word_print(addr);
+  low = bus_read_word_print(addr+2);
 
   return (high<<16)|low;
 }
@@ -292,32 +292,32 @@ LONG mmu_read_long_print(LONG addr)
  * if appropriate
  */
 
-BYTE mmu_read_byte(LONG addr)
+BYTE bus_read_byte(LONG addr)
 {
   return MEM_READ(byte, addr);
 }
 
-WORD mmu_read_word(LONG addr)
+WORD bus_read_word(LONG addr)
 {
   return MEM_READ(word, addr);
 }
 
-LONG mmu_read_long(LONG addr)
+LONG bus_read_long(LONG addr)
 {
   return MEM_READ(long, addr);
 }
 
-void mmu_write_byte(LONG addr, BYTE data)
+void bus_write_byte(LONG addr, BYTE data)
 {
   MEM_WRITE(byte, addr, data);
 }
 
-void mmu_write_word(LONG addr, WORD data)
+void bus_write_word(LONG addr, WORD data)
 {
   MEM_WRITE(word, addr, data);
 }
 
-void mmu_write_long(LONG addr, LONG data)
+void bus_write_long(LONG addr, LONG data)
 {
   MEM_WRITE(long, addr, data);
 }

--- a/mmu.h
+++ b/mmu.h
@@ -20,10 +20,8 @@ struct mmu {
   int verbosity;
   BYTE (*read_byte)(LONG);
   WORD (*read_word)(LONG);
-  LONG (*read_long)(LONG);
   void (*write_byte)(LONG, BYTE);
   void (*write_word)(LONG, WORD);
-  void (*write_long)(LONG, LONG);
   int (*state_collect)(struct mmu_state *);
   void (*state_restore)(struct mmu_state *);
   void (*diagnostics)();

--- a/mmu.h
+++ b/mmu.h
@@ -45,15 +45,15 @@ void mmu_send_bus_error(int, LONG);
 void mmu_print_map();
 void mmu_do_interrupts(struct cpu *);
 
-BYTE mmu_read_byte(LONG);
-WORD mmu_read_word(LONG);
-LONG mmu_read_long(LONG);
-BYTE mmu_read_byte_print(LONG);
-WORD mmu_read_word_print(LONG);
-LONG mmu_read_long_print(LONG);
-void mmu_write_byte(LONG, BYTE);
-void mmu_write_word(LONG, WORD);
-void mmu_write_long(LONG, LONG);
+BYTE bus_read_byte(LONG);
+WORD bus_read_word(LONG);
+LONG bus_read_long(LONG);
+BYTE bus_read_byte_print(LONG);
+WORD bus_read_word_print(LONG);
+LONG bus_read_long_print(LONG);
+void bus_write_byte(LONG, BYTE);
+void bus_write_word(LONG, WORD);
+void bus_write_long(LONG, LONG);
 
 extern int mmu_print_state;
 

--- a/mmu_fallback.c
+++ b/mmu_fallback.c
@@ -17,22 +17,12 @@ static WORD mmu_fallback_read_word(LONG addr)
   return 0xffff;
 }
 
-static LONG mmu_fallback_read_long(LONG addr)
-{
-  return 0xffffffff;
-}
-
 static void mmu_fallback_write_byte(LONG addr, BYTE data)
 {
   /* Do nothing here */
 }
 
 static void mmu_fallback_write_word(LONG addr, WORD data)
-{
-  /* Do nothing here */
-}
-
-static void mmu_fallback_write_long(LONG addr, LONG data)
 {
   /* Do nothing here */
 }
@@ -56,10 +46,8 @@ static void mmu_fallback_register(char *name, LONG addr, int size)
   mmu_fallback->size = size;
   mmu_fallback->read_byte = mmu_fallback_read_byte;
   mmu_fallback->read_word = mmu_fallback_read_word;
-  mmu_fallback->read_long = mmu_fallback_read_long;
   mmu_fallback->write_byte = mmu_fallback_write_byte;
   mmu_fallback->write_word = mmu_fallback_write_word;
-  mmu_fallback->write_long = mmu_fallback_write_long;
   mmu_fallback->state_collect = mmu_fallback_state_collect;
   mmu_fallback->state_restore = mmu_fallback_state_restore;
   mmu_fallback->diagnostics = mmu_fallback_diagnostics;

--- a/psg.c
+++ b/psg.c
@@ -199,14 +199,6 @@ static WORD psg_read_word(LONG addr)
   return (psg_read_byte(addr)<<8)|psg_read_byte(addr+1);
 }
 
-static LONG psg_read_long(LONG addr)
-{
-  return ((psg_read_byte(addr)<<24)|
-	  (psg_read_byte(addr+1)<<16)|
-	  (psg_read_byte(addr+2)<<8)|
-	  (psg_read_byte(addr+3)));
-}
-
 static void psg_write_byte(LONG addr, BYTE data)
 {
   if(addr&1) return;
@@ -230,14 +222,6 @@ static void psg_write_word(LONG addr, WORD data)
   psg_write_byte(addr+1, (data&0xff));
 }
 
-static void psg_write_long(LONG addr, LONG data)
-{
-  psg_write_byte(addr, (data&0xff000000)>>24);
-  psg_write_byte(addr+1, (data&0xff0000)>>16);
-  psg_write_byte(addr+2, (data&0xff00)>>8);
-  psg_write_byte(addr+3, (data&0xff));
-}
-
 static int psg_state_collect(struct mmu_state *state)
 {
   state->size = 0;
@@ -258,10 +242,8 @@ void psg_init()
   psg->size = PSGSIZE;
   psg->read_byte = psg_read_byte;
   psg->read_word = psg_read_word;
-  psg->read_long = psg_read_long;
   psg->write_byte = psg_write_byte;
   psg->write_word = psg_write_word;
-  psg->write_long = psg_write_long;
   psg->state_collect = psg_state_collect;
   psg->state_restore = psg_state_restore;
   psg->diagnostics = psg_diagnostics;

--- a/ram.c
+++ b/ram.c
@@ -33,14 +33,6 @@ WORD ram_read_word(LONG addr)
   return (ram_read_byte(addr)<<8)|ram_read_byte(addr+1);
 }
 
-static LONG ram_read_long(LONG addr)
-{
-  return ((ram_read_byte(addr)<<24)|
-       (ram_read_byte(addr+1)<<16)|
-       (ram_read_byte(addr+2)<<8)|
-       (ram_read_byte(addr+3)));
-}
-
 static void ram_write_byte(LONG addr, BYTE data)
 {
   *(real(addr)) = data;
@@ -50,14 +42,6 @@ static void ram_write_word(LONG addr, WORD data)
 {
   ram_write_byte(addr, (data&0xff00)>>8);
   ram_write_byte(addr+1, (data&0xff));
-}
-
-static void ram_write_long(LONG addr, LONG data)
-{
-  ram_write_byte(addr, (data&0xff000000)>>24);
-  ram_write_byte(addr+1, (data&0xff0000)>>16);
-  ram_write_byte(addr+2, (data&0xff00)>>8);
-  ram_write_byte(addr+3, (data&0xff));
 }
 
 static int ram_state_collect(struct mmu_state *state)
@@ -113,10 +97,8 @@ void ram_init()
   ram->size = RAMSIZE;
   ram->read_byte = ram_read_byte;
   ram->read_word = ram_read_word;
-  ram->read_long = ram_read_long;
   ram->write_byte = ram_write_byte;
   ram->write_word = ram_write_word;
-  ram->write_long = ram_write_long;
   ram->state_collect = ram_state_collect;
   ram->state_restore = ram_state_restore;
   ram->diagnostics = ram_diagnostics;

--- a/rom.c
+++ b/rom.c
@@ -42,14 +42,6 @@ static WORD rom_read_word(LONG addr)
   return (rom_read_byte(addr)<<8)|rom_read_byte(addr+1);
 }
 
-static LONG rom_read_long(LONG addr)
-{
-  return ((rom_read_byte(addr)<<24)|
-       (rom_read_byte(addr+1)<<16)|
-       (rom_read_byte(addr+2)<<8)|
-       (rom_read_byte(addr+3)));
-}
-
 static int rom_state_collect(struct mmu_state *state)
 {
   if(!strcmp("ROM0", state->id)) {
@@ -116,7 +108,6 @@ void rom_init()
   rom->size = ROMSIZE;
   rom->read_byte = rom_read_byte;
   rom->read_word = rom_read_word;
-  rom->read_long = rom_read_long;
   rom->state_collect = rom_state_collect;
   rom->state_restore = rom_state_restore;
   rom->diagnostics = rom_diagnostics;
@@ -140,7 +131,6 @@ void rom_init()
   rom2->size = ROMSIZE2;
   rom2->read_byte = rom_read_byte;
   rom2->read_word = rom_read_word;
-  rom2->read_long = rom_read_long;
   rom2->state_collect = rom_state_collect;
   rom2->state_restore = rom_state_restore;
   rom2->diagnostics = rom_diagnostics;

--- a/rtc.c
+++ b/rtc.c
@@ -20,14 +20,6 @@ static WORD rtc_read_word(LONG addr)
   return (rtc_read_byte(addr)<<8)|rtc_read_byte(addr+1);
 }
 
-static LONG rtc_read_long(LONG addr)
-{
-  return ((rtc_read_byte(addr)<<24)|
-	  (rtc_read_byte(addr+1)<<16)|
-	  (rtc_read_byte(addr+2)<<8)|
-	  (rtc_read_byte(addr+3)));
-}
-
 static void rtc_write_byte(LONG addr, BYTE data)
 {
 }
@@ -36,14 +28,6 @@ static void rtc_write_word(LONG addr, WORD data)
 {
   rtc_write_byte(addr, (data&0xff00)>>8);
   rtc_write_byte(addr+1, (data&0xff));
-}
-
-static void rtc_write_long(LONG addr, LONG data)
-{
-  rtc_write_byte(addr, (data&0xff000000)>>24);
-  rtc_write_byte(addr+1, (data&0xff0000)>>16);
-  rtc_write_byte(addr+2, (data&0xff00)>>8);
-  rtc_write_byte(addr+3, (data&0xff));
 }
 
 static int rtc_state_collect(struct mmu_state *state)
@@ -68,10 +52,8 @@ void rtc_init()
   rtc->size = RTCSIZE;
   rtc->read_byte = rtc_read_byte;
   rtc->read_word = rtc_read_word;
-  rtc->read_long = rtc_read_long;
   rtc->write_byte = rtc_write_byte;
   rtc->write_word = rtc_write_word;
-  rtc->write_long = rtc_write_long;
   rtc->state_collect = rtc_state_collect;
   rtc->state_restore = rtc_state_restore;
   rtc->diagnostics = rtc_diagnostics;

--- a/shifter.c
+++ b/shifter.c
@@ -484,14 +484,6 @@ static WORD shifter_read_word(LONG addr)
   return (shifter_read_byte(addr)<<8)|shifter_read_byte(addr+1);
 }
 
-static LONG shifter_read_long(LONG addr)
-{
-  return ((shifter_read_byte(addr)<<24)|
-          (shifter_read_byte(addr+1)<<16)|
-          (shifter_read_byte(addr+2)<<8)|
-          (shifter_read_byte(addr+3)));
-}
-
 static void shifter_write_byte(LONG addr, BYTE data)
 {
   WORD tmp;
@@ -543,17 +535,6 @@ static void shifter_write_word(LONG addr, WORD data)
     shifter_gen_picture(res.screen_cycles-vsynccnt);
   shifter_write_byte(addr, (data&0xff00)>>8);
   shifter_write_byte(addr+1, (data&0xff));
-}
-
-static void shifter_write_long(LONG addr, LONG data)
-{
-  if((addr >= 0xff8240) && (addr <= 0xff825f)) {
-    shifter_gen_picture(res.screen_cycles-vsynccnt);
-  }
-  shifter_write_byte(addr, (data&0xff000000)>>24);
-  shifter_write_byte(addr+1, (data&0xff0000)>>16);
-  shifter_write_byte(addr+2, (data&0xff00)>>8);
-  shifter_write_byte(addr+3, (data&0xff));
 }
 
 static int shifter_state_collect(struct mmu_state *state)
@@ -654,10 +635,8 @@ void shifter_init()
   shifter->size = SHIFTERSIZE;
   shifter->read_byte = shifter_read_byte;
   shifter->read_word = shifter_read_word;
-  shifter->read_long = shifter_read_long;
   shifter->write_byte = shifter_write_byte;
   shifter->write_word = shifter_write_word;
-  shifter->write_long = shifter_write_long;
   shifter->state_collect = shifter_state_collect;
   shifter->state_restore = shifter_state_restore;
   shifter->diagnostics = shifter_diagnostics;


### PR DESCRIPTION
The `mmu_` prefix no longer makes much sense.  It's not the MMU, but actually the GLUE which decides which device is responsible for which address range.  However, the consensus is that `bus_` is a better prefix.

There are no `long` bus accesses.

- Replace `mmu_` prefix with `bus_`.    Just a mechanical search/replace.
- Remove `_long` operations from `struct mmu`.  Also fairly mechanical.  
- Update `bus_read/write_long` to use `bus_read/write_word`.