### PR TITLE
Clocked MMU state machine

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -359,6 +359,7 @@ void cpu_do_cycle(LONG cnt)
 
   for(i = 0; i < cnt; i++) {
     glue_clock();
+    mmu_clock();
     shifter_clock();
   }
 }

--- a/glue.c
+++ b/glue.c
@@ -206,7 +206,7 @@ void glue_reset()
   h = v = 0;
   line = 0;
   line_end = 1000;
-  counter = 0;
+  counter = 0; // Here be wakestate.
   counter_end = 1000;
 }
 

--- a/mmu.h
+++ b/mmu.h
@@ -55,6 +55,7 @@ void bus_write_long(LONG, LONG);
 
 extern int mmu_print_state;
 
+void mmu_clock(void);
 void mmu_de(int);
 void mmu_vsync(void);
 

--- a/shifter.c
+++ b/shifter.c
@@ -104,9 +104,13 @@ static void shifter_set_resolution(BYTE data)
   res = res_data[data&3];
   glue_set_resolution(data & 3);
 
-  // This is just a hack to make things look good.  It's probably not
-  // what the shifter does when switching resolution.
-  reload = 16;
+  // This is a very ugly hack to make medium and high resolution work.
+  // It's absolutely not what a real shifter does when switching
+  // resolution.  Also, I have only a vague idea why this works.
+  if(data == 1)
+    reload = 20;
+  else if(data == 2)
+    reload = 24;
 }
 
 static BYTE shifter_read_byte(LONG addr)


### PR DESCRIPTION
 This updates the MMU to be a clock-driven state machine.

Only the DE and LOAD signals are handled in this fashion so far.  The primary feature is the addition of a 3-6 cycle delay from DE to LOAD.

Note that the MMU only fetches RAM at cycle 2 within a bus cycle. This is supposed to become a system-wide constraint, leaving cycle 0 for CPU and DMA.   