### PR TITLE
Accessing longwords should not result in two bus or address errors

### DIFF
--- a/mmu.h
+++ b/mmu.h
@@ -39,7 +39,6 @@ void mmu_state_restore(struct mmu_state *);
 void mmu_init();
 struct mmu *mmu_create(const char *, const char *);
 void mmu_register(struct mmu *);
-void mmu_send_bus_error(int, LONG);
 void mmu_print_map();
 void mmu_do_interrupts(struct cpu *);
 


### PR DESCRIPTION
 Ever since the change to remove all _long bus operation from all devices, BIG Demo has not been working.  This was due to bus_read_long doing two accesses, possibly resulting in two bus or address errors.  