### PR TITLE
GLUE doesn't need to align signals sent to MMU or shifter

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -190,10 +190,8 @@ void glue_clock(void)
 {
   if((counter & 1) == 0) {
     mode_fn();
-    if((counter & 3) == 0) {
-      mmu_de(h && v);
-      shifter_de(h && v);
-    }
+    mmu_de(h && v);
+    shifter_de(h && v);
   }
   counter++;
   ASSERT(counter <= 512);


### PR DESCRIPTION
 The DE signal from the GLUE to the MMU and shifter was only updated every four cycles.  That's not necessary any more.  In fact, it may cause problems now that the receiving components are simulated at the clock level.   