### PR TITLE
Check tracedelay: fix or remove

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -224,7 +224,6 @@ int cpu_step_instr(int trace)
 
     cpu->cyclecomp = 0;
     cpu->icycle = 0;
-    cpu->tracedelay = 0;
 
     if(cprint_all) {
       struct cprint *cprint;

--- a/cpu.h
+++ b/cpu.h
@@ -17,7 +17,6 @@ struct cpu {
   LONG icycle;
   int cyclecomp;
   int stopped;
-  int tracedelay;
   int debug_halted;
   int prefetched_instr;
   int has_prefetched;

--- a/cpu/andi_to_sr.c
+++ b/cpu/andi_to_sr.c
@@ -14,7 +14,6 @@ static void andi_to_sr(struct cpu *cpu, WORD op)
     d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr&d);
-    cpu->tracedelay = 1;
   } else {
     cpu_set_exception(8); /* Privilege violation */
   }

--- a/cpu/eori_to_sr.c
+++ b/cpu/eori_to_sr.c
@@ -14,7 +14,6 @@ static void eori_to_sr(struct cpu *cpu, WORD op)
     d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr^d);
-    cpu->tracedelay = 1;
   } else {
     cpu_set_exception(8); /* Privilege violation */
   }

--- a/cpu/move_to_sr.c
+++ b/cpu/move_to_sr.c
@@ -10,7 +10,6 @@ static void move_to_sr(struct cpu *cpu, WORD op)
   if(cpu->sr&0x2000) {
     ADD_CYCLE(12);
     cpu_set_sr(ea_read_word(cpu, op&0x3f, 0));
-    cpu->tracedelay = 1;
   } else {
     cpu_set_exception(8); /* Privilege violation */
   }

--- a/cpu/ori_to_sr.c
+++ b/cpu/ori_to_sr.c
@@ -14,7 +14,6 @@ static void ori_to_sr(struct cpu *cpu, WORD op)
     d = bus_read_word(cpu->pc);
     cpu->pc += 2;
     cpu_set_sr(cpu->sr|d);
-    cpu->tracedelay = 1;
   } else {
     cpu_set_exception(8); /* Privilege violation */
   }

--- a/cpu/rte.c
+++ b/cpu/rte.c
@@ -23,7 +23,6 @@ static void rte(struct cpu *cpu, WORD op)
 #endif
     cpu->pc = pc;
     cpu_set_sr(sr);
-    cpu->tracedelay = 1;
   } else {
     cpu_set_exception(8); /* Privilege violation */
   }


### PR DESCRIPTION
The `tracedelay` variable doesn't seem to be used any more.

Check whether tracing SR-changing instructions still work.  If so, remove `tracedelay`.  Otherwise, fix.