### PR TITLE
Make GLUE honour the sync register

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -59,7 +59,7 @@ static int line_end;
 static int line;
 static int counter;
 static int res = 0;
-static int freq = 2;
+static int freq = 0;
 
 HANDLE_DIAGNOSTICS(glue)
 

--- a/mmu.c
+++ b/mmu.c
@@ -325,6 +325,8 @@ void mmu_init()
   mmu->write_word = mmu_write_word;
   mmu->diagnostics = mmu_diagnostics;
   mmu_register(mmu);
+
+  glue_set_sync(0); // 60Hz is the default at power-up.
 }
 
 


### PR DESCRIPTION
 Now that 60Hz refresh rate works, we can make it the default at power-up.  When a PAL TOS version is used, it will switch to 50Hz. An NTSC TOS does nothing.  